### PR TITLE
Add larger note about submodules, to avoid build problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ make
 ./build/tjs
 ```
 
+*NOTE:* The txiki.js build depends on a number of git submodules (e.g. [curl](https://github.com/curl/curl), [libuv](https://github.com/libuv/libuv)). If you didn't already clone this repository recursively, make sure you initialize these submodules with `git submodule update --init` before proceeding to the build.
+
 [QuickJS]: https://bellard.org/quickjs/
 [libuv]: https://libuv.org/
 [full API]: API.md

--- a/README.md
+++ b/README.md
@@ -69,10 +69,11 @@ make
 ./build/tjs
 ```
 
-*NOTE:* The txiki.js build depends on a number of git submodules (e.g. [curl](https://github.com/curl/curl), [libuv](https://github.com/libuv/libuv)). If you didn't already clone this repository recursively, make sure you initialize these submodules with `git submodule update --init` before proceeding to the build.
+*NOTE:* The txiki.js build depends on a number of git submodules (e.g. [curl], [libuv]). If you didn't already clone this repository recursively, make sure you initialize these submodules with `git submodule update --init` before proceeding to the build.
 
 [QuickJS]: https://bellard.org/quickjs/
 [libuv]: https://libuv.org/
+[curl]: https://github.com/curl/curl
 [full API]: API.md
 [CMake]: https://cmake.org/
 [Ninja]: https://ninja-build.org/


### PR DESCRIPTION
I quickly scanned the build docs, and didn't notice the `--recursive` flag to `git clone` at first, resulting in a build failure:

```
make
cd build; cmake ../ -DCMAKE_BUILD_TYPE=Release -GNinja
-- Building in Release mode
-- Building with AppleClang 11.0.0.11000033 on Darwin-18.7.0
CMake Error at CMakeLists.txt:31 (add_subdirectory):
  The source directory

    /Users/humphd/repos/txiki.js/deps/libuv

  does not contain a CMakeLists.txt file.


--   DISABLE_CURL: OFF
--   USE_SYSTEM_CURL: ON
-- Configuring incomplete, errors occurred!
See also "/Users/humphd/repos/txiki.js/build/CMakeFiles/CMakeOutput.log".
make: *** [build/Makefile] Error 1
```

I've added a larger note in the README for other people like me who miss it!