### PR TITLE
build: don't use Ninja by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,7 @@ jobs:
         submodules: true
     - name: Prepare (Linux)
       if: matrix.operating-system == 'ubuntu-latest'
-      run: sudo apt install -y libcurl4-openssl-dev ninja-build
-    - name: Prepare (macOS)
-      if: matrix.operating-system == 'macOS-latest'
-      run: brew install ninja
+      run: sudo apt install -y libcurl4-openssl-dev
     - name: Build it
       run: make
     - name: Test it

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
       language: minimal
       before_install:
         - sudo docker run -dit --name tjs --volume "${PWD}:/mnt/tjs" --workdir /mnt/tjs alpine:latest
-        - sudo docker exec tjs apk add build-base cmake ninja curl-dev --update-cache
+        - sudo docker exec tjs apk add build-base cmake curl-dev --update-cache
       script: sudo docker exec tjs sh -c "make && make test"
     - name: macOS Clang system-CURL Debug
       os: osx
@@ -35,15 +35,6 @@ matrix:
     - name: macOS Clang system-CURL Release
       os: osx
       env: BUILDTYPE=Release
-addons:
-  apt:
-    update: true
-    packages:
-      - ninja-build
-  homebrew:
-    update: true
-    packages:
-      - ninja
 script:
   - make
   - ./build/tjs -e "console.log(JSON.stringify(tjs.versions))"

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,19 @@
 NINJA?=ninja
-
 BUILD_DIR=build
-CMAKE_MK=$(BUILD_DIR)/Makefile
-
 BUILDTYPE?=Release
 
 all: build
 
-build: $(CMAKE_MK)
-	$(NINJA) -C $(BUILD_DIR)
-
-$(CMAKE_MK):
+build:
 	@mkdir -p $(BUILD_DIR)
-	cd $(BUILD_DIR); cmake ../ -DCMAKE_BUILD_TYPE=$(BUILDTYPE) -GNinja
+	cd $(BUILD_DIR); cmake ../ -DCMAKE_BUILD_TYPE=$(BUILDTYPE)
+	$(MAKE) -C $(BUILD_DIR) -j8
 
 install:
-	@$(NINJA) -C $(BUILD_DIR) install
+	@$(MAKE) -C $(BUILD_DIR) install
 
 clean:
-	@$(NINJA) -C $(BUILD_DIR) clean
+	@$(MAKE) -C $(BUILD_DIR) clean
 
 distclean:
 	@rm -rf $(BUILD_DIR)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Other extras:
 
 ## Building
 
-[CMake] and [Ninja] are necessary.
+[CMake] is necessary.
 
 ```bash
 # Get the code
@@ -76,4 +76,3 @@ make
 [curl]: https://github.com/curl/curl
 [full API]: API.md
 [CMake]: https://cmake.org/
-[Ninja]: https://ninja-build.org/


### PR DESCRIPTION
It makes CI testing slower because it must be installed first. It can
still be ran manually.