### PR TITLE
minimal multi-stage Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:latest
+ENV VERSION 20191124
+WORKDIR /
+RUN apk add build-base cmake curl-dev git --update-cache
+RUN git clone --recursive https://github.com/saghul/txiki.js && cd txiki.js && make && make test
+
+FROM alpine:latest
+RUN apk add libstdc++ libcurl --update-cache
+COPY --from=0 /txiki.js/build/tjs /bin/tjs
+COPY --from=0 /txiki.js/examples /examples
+CMD [ "tjs" ]


### PR DESCRIPTION
Produces a minimal Apline image w/ tjs executable + shared libs in about 16MB of space