### PR TITLE
Rename 'hrtime' to 'hrtimeBigInt'

### DIFF
--- a/src/js/performance.js
+++ b/src/js/performance.js
@@ -13,7 +13,7 @@ class Performance {
     }
 
     now() {
-        return tjs.hrtimeBigInt() - this._startTime;
+        return Number(tjs.hrtimeBigInt() - this._startTime);
     }
 
     mark(name) {

--- a/src/js/performance.js
+++ b/src/js/performance.js
@@ -3,7 +3,7 @@
 // Derived from: https://github.com/blackswanny/performance-polyfill
 class Performance {
     constructor() {
-        this._startTime = tjs.hrtime();
+        this._startTime = tjs.hrtimeBigInt();
         this._entries = [];
         this._marksIndex = Object.create(null);
     }
@@ -13,7 +13,7 @@ class Performance {
     }
 
     now() {
-        return tjs.hrtime() - this._startTime;
+        return tjs.hrtimeBigInt() - this._startTime;
     }
 
     mark(name) {

--- a/src/misc.c
+++ b/src/misc.c
@@ -35,8 +35,20 @@
 #include <replxx.h>
 
 
-static JSValue tjs_hrtime(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
+static JSValue tjs_hrtimeBigInt(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
     return JS_NewBigUint64(ctx, uv_hrtime());
+}
+
+static JSValue tjs_hrtime(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
+    uint64_t nanosecs = uv_hrtime();
+    unsigned secs = nanosecs / 1000000000ULL;
+    unsigned nanos = nanosecs - secs;
+
+    JSValue ret = JS_NewArray(ctx);
+    JS_SetPropertyUint32(ctx, ret, 0, JS_NewInt32(ctx, secs));
+    JS_SetPropertyUint32(ctx, ret, 1, JS_NewInt32(ctx, nanos));
+
+    return ret;
 }
 
 static JSValue tjs_gettimeofday(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
@@ -356,7 +368,7 @@ static const JSCFunctionListEntry tjs_misc_funcs[] = {
     TJS_CONST(UV_UDP_IPV6ONLY),
     TJS_CONST(UV_UDP_PARTIAL),
     TJS_CONST(UV_UDP_REUSEADDR),
-    JS_CFUNC_DEF("hrtime", 0, tjs_hrtime),
+    JS_CFUNC_DEF("hrtimeBigInt", 0, tjs_hrtimeBigInt),
     JS_CFUNC_DEF("gettimeofday", 0, tjs_gettimeofday),
     JS_CFUNC_DEF("uname", 0, tjs_uname),
     JS_CFUNC_DEF("isatty", 1, tjs_isatty),

--- a/src/misc.c
+++ b/src/misc.c
@@ -41,12 +41,12 @@ static JSValue tjs_hrtimeBigInt(JSContext *ctx, JSValueConst this_val, int argc,
 
 static JSValue tjs_hrtime(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
     uint64_t nanosecs = uv_hrtime();
-    unsigned secs = nanosecs / 1000000000ULL;
-    unsigned nanos = nanosecs - secs;
+    uint64_t secs = nanosecs / 1000000000ULL;
+    uint64_t remainingNanosecs = nanosecs - (secs * 1000000000ULL);
 
     JSValue ret = JS_NewArray(ctx);
-    JS_SetPropertyUint32(ctx, ret, 0, JS_NewInt32(ctx, secs));
-    JS_SetPropertyUint32(ctx, ret, 1, JS_NewInt32(ctx, nanos));
+    JS_SetPropertyUint32(ctx, ret, 0, JS_NewInt64(ctx, secs));
+    JS_SetPropertyUint32(ctx, ret, 1, JS_NewInt64(ctx, remainingNanosecs));
 
     return ret;
 }

--- a/src/misc.c
+++ b/src/misc.c
@@ -368,6 +368,7 @@ static const JSCFunctionListEntry tjs_misc_funcs[] = {
     TJS_CONST(UV_UDP_IPV6ONLY),
     TJS_CONST(UV_UDP_PARTIAL),
     TJS_CONST(UV_UDP_REUSEADDR),
+    JS_CFUNC_DEF("hrtime", 0, tjs_hrtime),
     JS_CFUNC_DEF("hrtimeBigInt", 0, tjs_hrtimeBigInt),
     JS_CFUNC_DEF("gettimeofday", 0, tjs_gettimeofday),
     JS_CFUNC_DEF("uname", 0, tjs_uname),

--- a/tests/run.js
+++ b/tests/run.js
@@ -13,5 +13,6 @@ import './test-uuid.js';
 import './test-version.js';
 import './test-xhr.js';
 import './test-worker.js';
+import './test-hrtime.js';
 
 run();

--- a/tests/test-hrtime.js
+++ b/tests/test-hrtime.js
@@ -1,0 +1,19 @@
+import { run, test } from './t.js';
+
+test('hrtime test', t => {
+  const time = tjs.hrtime()
+  t.ok(Array.isArray(time))
+  t.ok(time.length == 2)
+  t.ok(typeof time[0] == 'number')
+  t.ok(typeof time[1] == 'number')
+});
+
+test('hrtimeBigInt test', t => {
+  const time = tjs.hrtimeBigInt()
+  t.ok(typeof time == 'bigint')
+  t.ok(time > 0)
+});
+
+if (import.meta.main) {
+    run();
+}

--- a/tests/test-performance.js
+++ b/tests/test-performance.js
@@ -2,6 +2,7 @@ import { run, sleep, test } from './t.js';
 
 test('performance now', async t => {
     const start = performance.now();
+    t.ok(typeof start == 'number', 'performance.now() returns number (for now)');
     await sleep(100);
     t.ok(performance.now() - start >= 100, 'performance.now() works');
 });


### PR DESCRIPTION
According to Node docs, hrtime should return a tuple of size 2 `[seconds: number, nanoseconds: number]`, and it is hrtimeBigInt to actually be the full size with nanoseconds.