### PR TITLE
Allow globals to be monkey patched

### DIFF
--- a/src/js/bootstrap.js
+++ b/src/js/bootstrap.js
@@ -14,14 +14,12 @@ globalThis.prompt = tjs.prompt;
 
 Object.defineProperty(globalThis, 'global', {
     enumerable: true,
-    configurable: true,
-    writable: true,
-    value: globalThis
+    get() { return globalThis },
+    set() {}
 });
 
 Object.defineProperty(globalThis, 'window', {
     enumerable: true,
-    configurable: true,
-    writable: true,
-    value: globalThis
+    get() { return globalThis },
+    set() {}
 });

--- a/src/js/bootstrap.js
+++ b/src/js/bootstrap.js
@@ -14,14 +14,14 @@ globalThis.prompt = tjs.prompt;
 
 Object.defineProperty(globalThis, 'global', {
     enumerable: true,
-    configurable: false,
-    writable: false,
+    configurable: true,
+    writable: true,
     value: globalThis
 });
 
 Object.defineProperty(globalThis, 'window', {
     enumerable: true,
-    configurable: false,
-    writable: false,
+    configurable: true,
+    writable: true,
     value: globalThis
 });

--- a/src/js/bootstrap2.js
+++ b/src/js/bootstrap2.js
@@ -14,8 +14,8 @@ import { Performance } from '@tjs/performance';
 
 Object.defineProperty(window, 'console', {
     enumerable: true,
-    configurable: false,
-    writable: false,
+    configurable: true,
+    writable: true,
     value: new Console()
 });
 
@@ -70,32 +70,32 @@ class MessageEvent extends Event {
 Object.defineProperties(window, {
     EventTarget: {
         enumerable: true,
-        configurable: false,
-        writable: false,
+        configurable: true,
+        writable: true,
         value: EventTarget
     },
     Event: {
         enumerable: true,
-        configurable: false,
-        writable: false,
+        configurable: true,
+        writable: true,
         value: Event
     },
     ErrorEvent: {
         enumerable: true,
-        configurable: false,
-        writable: false,
+        configurable: true,
+        writable: true,
         value: ErrorEvent
     },
     MessageEvent: {
         enumerable: true,
-        configurable: false,
-        writable: false,
+        configurable: true,
+        writable: true,
         value: MessageEvent
     },
     CustomEvent: {
         enumerable: true,
-        configurable: false,
-        writable: false,
+        configurable: true,
+        writable: true,
         value: CustomEvent
     }
 });
@@ -111,8 +111,8 @@ defineEventAttribute(Object.getPrototypeOf(window), 'load');
 
 Object.defineProperty(window, 'performance', {
     enumerable: true,
-    configurable: false,
-    writable: false,
+    configurable: true,
+    writable: true,
     value: new Performance()
 });
 
@@ -122,15 +122,15 @@ Object.defineProperty(window, 'performance', {
 
 Object.defineProperty(window, 'AbortController', {
     enumerable: true,
-    configurable: false,
-    writable: false,
+    configurable: true,
+    writable: true,
     value: AbortController
 });
 
 Object.defineProperty(window, 'AbortSignal', {
     enumerable: true,
-    configurable: false,
-    writable: false,
+    configurable: true,
+    writable: true,
     value: AbortSignal
 });
 
@@ -173,7 +173,7 @@ defineEventAttribute(Object.getPrototypeOf(Worker), 'error');
 
 Object.defineProperty(window, 'Worker', {
     enumerable: true,
-    configurable: false,
-    writable: false,
+    configurable: true,
+    writable: true,
     value: Worker
 });

--- a/src/js/crypto.js
+++ b/src/js/crypto.js
@@ -36,7 +36,7 @@ const crypto = Object.freeze({
 
 Object.defineProperty(window, 'crypto', {
     enumerable: true,
-    configurable: false,
-    writable: false,
+    configurable: true,
+    writable: true,
     value: crypto
 });

--- a/tests/test-global-window.js
+++ b/tests/test-global-window.js
@@ -1,12 +1,12 @@
 import { run, test } from './t.js';
 
-test('global is not configurable / writable', t => {
-    t.throws(() => { globalThis.global = 'foo'; }, TypeError, 'assigning global throws');
+test('should be futile to rewriting global', t => {
+    globalThis.global = 'foo';
     t.is(globalThis, global, 'globalThis is global')
 });
 
-test('window is not configurable / writable', t => {
-    t.throws(() => { globalThis.window = 'foo'; }, TypeError, 'assigning window throws');
+test('should be futile to rewriting window', t => {
+    globalThis.window = 'foo';
     t.is(globalThis, window, 'globalThis is window')
 });
 


### PR DESCRIPTION
This would really help to use some polyfill properly, e.g. polyfills from Babel, from Browserify, these cannot be applied to e.g. Event class right now.

BTW, with this PR you should be able to run JSDOM from now on

1. `npm install jsdom`
2. Create the following snippet 'jsdom.browserify.src.js'
```js
const jsdom = require('jsdom')
global.jsdom = jsdom // workaround for qjs, there is no module.exports available
```
3. Run `browserify -r jsdom -s jsdom -o jsdom.browserify.js jsdom.browserify.src.js`
4. Run `jsdom.browserify.js` file within txiki.js
5. ???
6. Have fun