### PR TITLE
Add fs to globals

### DIFF
--- a/src/js/bootstrap.js
+++ b/src/js/bootstrap.js
@@ -4,6 +4,7 @@
 import * as tjs from '@tjs/core';
 
 globalThis.tjs = tjs;
+globalThis.fs = tjs.fs;
 globalThis.setTimeout = tjs.setTimeout;
 globalThis.clearTimeout = tjs.clearTimeout;
 globalThis.setInterval = tjs.setInterval;

--- a/src/js/repl.js
+++ b/src/js/repl.js
@@ -32,6 +32,7 @@ import * as uuid from "@tjs/uuid";
     g.hashlib = hashlib;
     g.path = path;
     g.uuid = uuid;
+    g.fs = tjs.fs;
 
     /* close global objects */
     var Object = g.Object;

--- a/tests/run.js
+++ b/tests/run.js
@@ -13,5 +13,6 @@ import './test-uuid.js';
 import './test-version.js';
 import './test-xhr.js';
 import './test-worker.js';
+import './test-globals-existence.js';
 
 run();

--- a/tests/test-globals-existence.js
+++ b/tests/test-globals-existence.js
@@ -1,0 +1,11 @@
+import { run, test } from './t.js';
+
+test('global existence', t => {
+  t.ok(fs)
+  t.ok(typeof fs !== 'undefined')
+});
+
+
+if (import.meta.main) {
+    run();
+}


### PR DESCRIPTION
We should have some globals by default, rather than sticking them to tjs object. Right now I see fs can be one to be exposed for Node compatibility.