### PR TITLE
core: fix promise microtask running sequence

### DIFF
--- a/src/private.h
+++ b/src/private.h
@@ -98,6 +98,8 @@ JSValue tjs_throw_errno(JSContext *ctx, int err);
 JSValue tjs_new_pipe(JSContext *ctx);
 uv_stream_t *tjs_pipe_get_stream(JSContext *ctx, JSValueConst obj);
 
+void tjs_execute_jobs(JSContext *ctx);
+
 int tjs__load_file(JSContext *ctx, DynBuf *dbuf, const char *filename);
 JSModuleDef *tjs_module_loader(JSContext *ctx, const char *module_name, void *opaque);
 char *tjs_module_normalizer(JSContext *ctx, const char *base_name, const char *name, void *opaque);

--- a/src/timers.c
+++ b/src/timers.c
@@ -65,21 +65,6 @@ static void call_timer(TJSTimer *th) {
     JS_FreeValue(ctx, ret);
 }
 
-static void execute_jobs(TJSTimer *th) {
-    JSContext *ctx = th->ctx;
-    JSRuntime *rt = JS_GetRuntime(ctx);
-    int err;
-
-    for (;;) {
-        err = JS_ExecutePendingJob(rt, &ctx);
-        if (err <= 0) {
-            if (err < 0)
-                tjs_dump_error(ctx);
-            break;
-        }
-    }
-}
-
 static void uv__timer_close(uv_handle_t *handle) {
     TJSTimer *th = handle->data;
     CHECK_NOT_NULL(th);
@@ -92,7 +77,7 @@ static void uv__timer_cb(uv_timer_t *handle) {
 
     /* Timer always executes before check phase in libuv,
        so clear the microtask queue here before running setTimeout macrotasks */
-    execute_jobs(th);
+    tjs_execute_jobs(th->ctx);
 
     call_timer(th);
     if (!th->interval)

--- a/src/vm.c
+++ b/src/vm.c
@@ -259,15 +259,15 @@ static void uv__prepare_cb(uv_prepare_t *handle) {
 }
 
 void tjs_execute_jobs(JSContext *ctx) {
-    JSRuntime *rt = JS_GetRuntime(ctx);
+    JSContext *ctx1;
     int err;
 
     /* execute the pending jobs */
     for (;;) {
-        err = JS_ExecutePendingJob(rt, &ctx);
+        err = JS_ExecutePendingJob(JS_GetRuntime(ctx), &ctx1);
         if (err <= 0) {
             if (err < 0)
-                tjs_dump_error(ctx);
+                tjs_dump_error(ctx1);
             break;
         }
     }

--- a/src/vm.c
+++ b/src/vm.c
@@ -258,23 +258,26 @@ static void uv__prepare_cb(uv_prepare_t *handle) {
     uv__maybe_idle(qrt);
 }
 
-static void uv__check_cb(uv_check_t *handle) {
-    TJSRuntime *qrt = handle->data;
-    CHECK_NOT_NULL(qrt);
-
-    JSRuntime *rt = qrt->rt;
-    JSContext *ctx1;
+void tjs_execute_jobs(JSContext *ctx) {
+    JSRuntime *rt = JS_GetRuntime(ctx);
     int err;
 
     /* execute the pending jobs */
     for (;;) {
-        err = JS_ExecutePendingJob(rt, &ctx1);
+        err = JS_ExecutePendingJob(rt, &ctx);
         if (err <= 0) {
             if (err < 0)
-                tjs_dump_error(ctx1);
+                tjs_dump_error(ctx);
             break;
         }
     }
+}
+
+static void uv__check_cb(uv_check_t *handle) {
+    TJSRuntime *qrt = handle->data;
+    CHECK_NOT_NULL(qrt);
+
+    tjs_execute_jobs(qrt->ctx);
 
     uv__maybe_idle(qrt);
 }

--- a/tests/run.js
+++ b/tests/run.js
@@ -9,6 +9,7 @@ import './test-import-http.js';
 import './test-noop.js';
 import './test-performance.js';
 import './test-random.js';
+import './test-timer.js';
 import './test-uuid.js';
 import './test-version.js';
 import './test-xhr.js';

--- a/tests/test-timer.js
+++ b/tests/test-timer.js
@@ -1,0 +1,63 @@
+import { run, test } from './t.js';
+
+test('basic timer', async t => {
+    const runner1 = () => Promise.resolve();
+    await runner1();
+    t.ok(true, 'Promise microtask should be supported');
+
+    const runner2 = () => {
+        return new Promise((resolve, reject) => {
+            setTimeout(() => {
+                resolve();
+            }, 100);
+        });
+    };
+    await runner2();
+    t.ok(true, 'setTimeout timer should be supported');
+});
+
+test('async task sequence', async t => {
+    const runner1 = () => {
+        let str = '';
+        return new Promise((resolve, reject) => {
+            setTimeout(() => {
+                str += 'B';
+                resolve(str);
+            }, 0);
+            Promise.resolve().then(() => str += 'A');
+        });
+    };
+    const result1 = await runner1();
+    t.equal(result1, 'AB', 'Promise microtask should run before setTimeout');
+
+
+    const runner2 = () => {
+        let str = '';
+        return new Promise((resolve, reject) => {
+            setTimeout(() => str += 'B', 0);
+            Promise.resolve().then(() => str += 'A');
+    
+            setTimeout(() => {
+                setTimeout(() => {
+                    setTimeout(() => {
+                        str += 'H';
+                        resolve(str);
+                    }, 0);
+                    str += 'D';
+                    Promise.resolve().then(() => str += 'E');
+                    Promise.resolve().then(() => str += 'F');
+                    Promise.resolve().then(() => str += 'G');
+                }, 0);
+                Promise.resolve().then(() => str += 'C');
+            }, 100);
+        });
+    };
+
+    const result2 = await runner2();
+    t.equal(result2, 'ABCDEFGH', 'nesting task sequence matches');
+});
+
+
+if (import.meta.main) {
+    run();
+}


### PR DESCRIPTION
Fix #107 

We don't have to migrate to `UV_RUN_ONCE` for this case. This PR simply executes the microtask jobs before the `setTimeout` callback, which makes the `Promise.then` microtasks can be always cleared before `setTimeout`.

I've verified the basic and the nesting callback case in the original issue.