### PR TITLE
Revert "vm: use a 10MB default stack size"

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -28,7 +28,7 @@
 
 #include <string.h>
 
-#define TJS__DEFAULT_STACK_SIZE 10 * 1024 * 1024
+#define TJS__DEFAULT_STACK_SIZE 1048576
 
 INCTXT(repl, "repl.js");
 

--- a/tests/advanced/test-jsdom.js
+++ b/tests/advanced/test-jsdom.js
@@ -1,5 +1,9 @@
 import assert from '../assert.js';
 
+if (tjs.platform === 'linux' && tjs.environ()['CI']) {
+    // Skip test on Linux, it creates a stack overflow on some CIs.
+    tjs.exit(0);
+}
 
 (async () => {
   await import('./generated/jsdom.js')


### PR DESCRIPTION
This reverts commit ffa4b191eeb23984d502b183a1f521be717f1eb5.