### PR TITLE
build: remove compile time disabling curl and wasm3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,34 +64,27 @@ add_subdirectory(deps/quickjs EXCLUDE_FROM_ALL)
 option(libuv_buildtests "" OFF)
 add_subdirectory(deps/libuv EXCLUDE_FROM_ALL)
 
-cpr_option(DISABLE_WASM "If ON, WASM support will be disabled" OFF)
-if (NOT DISABLE_WASM)
-    set(BUILD_WASI "simple" CACHE STRING "WASI implementation")
-    add_subdirectory(deps/wasm3 EXCLUDE_FROM_ALL)
-endif()
+set(BUILD_WASI "simple" CACHE STRING "WASI implementation")
+add_subdirectory(deps/wasm3 EXCLUDE_FROM_ALL)
 
-cpr_option(DISABLE_CURL "If ON, curl support will be disabled" OFF)
 cpr_option(USE_SYSTEM_CURL "If ON, this project will look in the system paths for an installed curl library" ON)
-
-if(NOT DISABLE_CURL)
-    if(USE_SYSTEM_CURL)
-        find_package(CURL)
+if(USE_SYSTEM_CURL)
+    find_package(CURL)
+endif()
+if(NOT USE_SYSTEM_CURL OR NOT CURL_FOUND)
+    message(STATUS "Not using system curl, using built-in curl project instead.")
+    option(HTTP_ONLY "disables all protocols except HTTP" ON)
+    option(BUILD_TESTING "Set to ON to build cURL tests." OFF)
+    option(BUILD_CURL_EXE "Set to ON to build cURL executable." OFF)
+    if(APPLE)
+        option(CMAKE_USE_SECTRANSP "Enable Apple OS native SSL/TLS" ON)
     endif()
-    if(NOT USE_SYSTEM_CURL OR NOT CURL_FOUND)
-        message(STATUS "Not using system Curl, using built-in curl project instead.")
-        option(HTTP_ONLY "disables all protocols except HTTP" ON)
-        option(BUILD_TESTING "Set to ON to build cURL tests." OFF)
-        option(BUILD_CURL_EXE "Set to ON to build cURL executable." OFF)
-        if(APPLE)
-            option(CMAKE_USE_SECTRANSP "Enable Apple OS native SSL/TLS" ON)
-        endif()
-        add_subdirectory(deps/curl)
-        set(CURL_FOUND TRUE)
-        set(CURL_LIBRARIES libcurl)
-        set(CURL_INCLUDE_DIRS
-            ${CURL_SOURCE_DIR}/include
-            ${CURL_BINARY_DIR}/include/curl)
-    endif()
+    add_subdirectory(deps/curl)
+    set(CURL_FOUND TRUE)
+    set(CURL_LIBRARIES libcurl)
+    set(CURL_INCLUDE_DIRS
+        ${CURL_SOURCE_DIR}/include
+        ${CURL_BINARY_DIR}/include/curl)
 endif()
 
 add_executable(tjs
@@ -124,27 +117,7 @@ set_target_properties(tjs PROPERTIES
     C_STANDARD_REQUIRED ON
 )
 
-if (CURL_FOUND)
-    if (USE_SYSTEM_CURL)
-        target_compile_definitions(tjs PRIVATE
-            TJS_HAVE_SYSTEM_CURL
-        )
-    endif()
-    target_compile_definitions(tjs PRIVATE
-        TJS_HAVE_CURL
-    )
-    target_include_directories(tjs PRIVATE ${CURL_INCLUDE_DIRS})
-    target_link_libraries(tjs ${CURL_LIBRARIES})
-endif()
-
 string(TOLOWER ${CMAKE_SYSTEM_NAME} TJS_PLATFORM)
 target_compile_definitions(tjs PRIVATE TJS__PLATFORM="${TJS_PLATFORM}")
-
-if (NOT DISABLE_WASM)
-    target_compile_definitions(tjs PRIVATE
-        TJS_HAVE_WASM
-    )
-    target_link_libraries(tjs m3)
-endif()
-
-target_link_libraries(tjs qjs uv_a m)
+target_include_directories(tjs PRIVATE ${CURL_INCLUDE_DIRS})
+target_link_libraries(tjs qjs uv_a m3 m ${CURL_LIBRARIES})

--- a/src/curl-utils.c
+++ b/src/curl-utils.c
@@ -25,8 +25,6 @@
 #include "curl-utils.h"
 
 
-#ifdef TJS_HAVE_CURL
-
 static uv_once_t curl__init_once = UV_ONCE_INIT;
 
 void tjs__curl_init_once(void) {
@@ -250,5 +248,3 @@ CURLM *tjs__get_curlm(JSContext *ctx) {
 
     return qrt->curl_ctx.curlm_h;
 }
-
-#endif

--- a/src/curl-utils.h
+++ b/src/curl-utils.h
@@ -26,8 +26,6 @@
 #include "tjs.h"
 
 
-#ifdef TJS_HAVE_CURL
-
 #include <curl/curl.h>
 
 
@@ -40,5 +38,3 @@ typedef struct {
 void tjs_curl_init(void);
 int tjs_curl_load_http(DynBuf *dbuf, const char *url);
 CURLM *tjs__get_curlm(JSContext *ctx);
-
-#endif

--- a/src/misc.c
+++ b/src/misc.c
@@ -30,9 +30,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#ifdef TJS_HAVE_CURL
 #include <curl/curl.h>
-#endif
 
 
 static JSValue tjs_hrtime(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
@@ -398,18 +396,8 @@ void tjs_mod_misc_init(JSContext *ctx, JSModuleDef *m) {
     JS_DefinePropertyValueStr(ctx, versions, "quickjs", JS_NewString(ctx, QJS_VERSION_STR), JS_PROP_C_W_E);
     JS_DefinePropertyValueStr(ctx, versions, "tjs", JS_NewString(ctx, tjs_version()), JS_PROP_C_W_E);
     JS_DefinePropertyValueStr(ctx, versions, "uv", JS_NewString(ctx, uv_version_string()), JS_PROP_C_W_E);
-#ifdef TJS_HAVE_CURL
-#ifdef TJS_HAVE_SYSTEM_CURL
-    JS_DefinePropertyValueStr(ctx, versions, "curl", JS_NewString(ctx, "system"), JS_PROP_C_W_E);
-#else
     JS_DefinePropertyValueStr(ctx, versions, "curl", JS_NewString(ctx, curl_version()), JS_PROP_C_W_E);
-#endif
-#else
-    JS_DefinePropertyValueStr(ctx, versions, "curl", JS_UNDEFINED, JS_PROP_C_W_E);
-#endif
-#ifdef TJS_HAVE_WASM
     JS_DefinePropertyValueStr(ctx, versions, "wasm3", JS_NewString(ctx, M3_VERSION), JS_PROP_C_W_E);
-#endif
     JS_SetModuleExport(ctx, m, "versions", versions);
 }
 

--- a/src/modules.c
+++ b/src/modules.c
@@ -30,8 +30,6 @@
 #include <string.h>
 
 
-#ifdef TJS_HAVE_CURL
-
 JSModuleDef *tjs__load_http(JSContext *ctx, const char *url) {
     JSModuleDef *m;
     DynBuf dbuf;
@@ -66,8 +64,6 @@ end:
     return m;
 }
 
-#endif
-
 JSModuleDef *tjs_module_loader(JSContext *ctx, const char *module_name, void *opaque) {
     static const char http[] = "http://";
     static const char https[] = "https://";
@@ -80,12 +76,7 @@ JSModuleDef *tjs_module_loader(JSContext *ctx, const char *module_name, void *op
     DynBuf dbuf;
 
     if (strncmp(http, module_name, strlen(http)) == 0 || strncmp(https, module_name, strlen(https)) == 0) {
-#ifdef TJS_HAVE_CURL
         return tjs__load_http(ctx, module_name);
-#else
-        JS_ThrowReferenceError(ctx, "could not load '%s', libcurl support not enabled", module_name);
-        return NULL;
-#endif
     }
 
     dbuf_init(&dbuf);

--- a/src/private.h
+++ b/src/private.h
@@ -30,13 +30,10 @@
 #include "tjs.h"
 #include "wasm.h"
 
+#include <curl/curl.h>
 #include <quickjs.h>
 #include <stdbool.h>
 #include <uv.h>
-
-#ifdef TJS_HAVE_CURL
-#include <curl/curl.h>
-#endif
 
 
 struct TJSRuntime {
@@ -52,17 +49,13 @@ struct TJSRuntime {
     uv_async_t stop;
     bool is_worker;
     bool in_bootstrap;
-#ifdef TJS_HAVE_CURL
     struct {
         CURLM *curlm_h;
         uv_timer_t timer;
     } curl_ctx;
-#endif
-#ifdef TJS_HAVE_WASM
     struct {
         IM3Environment env;
     } wasm_ctx;
-#endif
     struct {
         JSValue u8array_ctor;
     } builtins;

--- a/src/vm.c
+++ b/src/vm.c
@@ -57,13 +57,9 @@ static int tjs_init(JSContext *ctx, JSModuleDef *m) {
     tjs_mod_streams_init(ctx, m);
     tjs_mod_timers_init(ctx, m);
     tjs_mod_udp_init(ctx, m);
-#ifdef TJS_HAVE_WASM
     tjs_mod_wasm_init(ctx, m);
-#endif
     tjs_mod_worker_init(ctx, m);
-#ifdef TJS_HAVE_CURL
     tjs_mod_xhr_init(ctx, m);
-#endif
 
     return 0;
 }
@@ -85,13 +81,9 @@ JSModuleDef *js_init_module_uv(JSContext *ctx, const char *name) {
     tjs_mod_signals_export(ctx, m);
     tjs_mod_timers_export(ctx, m);
     tjs_mod_udp_export(ctx, m);
-#ifdef TJS_HAVE_WASM
     tjs_mod_wasm_export(ctx, m);
-#endif
     tjs_mod_worker_export(ctx, m);
-#ifdef TJS_HAVE_CURL
     tjs_mod_xhr_export(ctx, m);
-#endif
 
     return m;
 }
@@ -246,9 +238,7 @@ TJSRuntime *TJS_NewRuntimeInternal(bool is_worker, TJSRunOptions *options) {
     qrt->in_bootstrap = false;
 
     /* WASM */
-#ifdef TJS_HAVE_WASM
     qrt->wasm_ctx.env = m3_NewEnvironment();
-#endif
 
     /* Load some builtin references for easy access */
     JSValue global_obj = JS_GetGlobalObject(qrt->ctx);
@@ -271,18 +261,14 @@ void TJS_FreeRuntime(TJSRuntime *qrt) {
     JS_FreeContext(qrt->ctx);
     JS_FreeRuntime(qrt->rt);
 
-    /* Destroy CURLM hande. */
-#ifdef TJS_HAVE_CURL
+    /* Destroy CURLM handle. */
     if (qrt->curl_ctx.curlm_h) {
         curl_multi_cleanup(qrt->curl_ctx.curlm_h);
         uv_close((uv_handle_t *) &qrt->curl_ctx.timer, NULL);
     }
-#endif
 
     /* Destroy WASM runtime. */
-#ifdef TJS_HAVE_WASM
     m3_FreeEnvironment(qrt->wasm_ctx.env);
-#endif
 
     /* Cleanup loop. All handles should be closed. */
     int closed = 0;

--- a/src/wasm.c
+++ b/src/wasm.c
@@ -28,8 +28,6 @@
 #include "tjs.h"
 #include "utils.h"
 
-#ifdef TJS_HAVE_WASM
-
 #define TJS__WASM_MAX_ARGS 32
 
 static JSClassID tjs_wasm_module_class_id;
@@ -379,5 +377,3 @@ void tjs_mod_wasm_init(JSContext *ctx, JSModuleDef *m) {
 void tjs_mod_wasm_export(JSContext *ctx, JSModuleDef *m) {
     JS_AddModuleExport(ctx, m, "wasm");
 }
-
-#endif

--- a/src/wasm.h
+++ b/src/wasm.h
@@ -25,11 +25,9 @@
 #ifndef TJS_WASM_H
 #define TJS_WASM_H
 
-#ifdef TJS_HAVE_WASM
 #include <wasm3.h>
 #include <m3_api_wasi.h>
 // XXX: Needed for enumerating a module's functions
 #include <m3_env.h>
-#endif
 
 #endif

--- a/src/xhr.c
+++ b/src/xhr.c
@@ -28,8 +28,6 @@
 #include <ctype.h>
 #include <string.h>
 
-#ifdef TJS_HAVE_CURL
-
 
 enum {
     XHR_EVENT_ABORT = 0,
@@ -787,5 +785,3 @@ void tjs_mod_xhr_init(JSContext *ctx, JSModuleDef *m) {
 void tjs_mod_xhr_export(JSContext *ctx, JSModuleDef *m) {
     JS_AddModuleExport(ctx, m, "XMLHttpRequest");
 }
-
-#endif


### PR DESCRIPTION
They bring essential web platform APIs. Optiong out was also not 100% correctly
implemented anyway.