### PR TITLE
core: refactor bootstrap

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -135,7 +135,7 @@ static JSValue tjs_dns_getaddrinfo(JSContext *ctx, JSValueConst this_val, int ar
 }
 
 static const JSCFunctionListEntry tjs_dns_funcs[] = {
-    JS_CFUNC_DEF("getaddrinfo", 2, tjs_dns_getaddrinfo),
+    TJS_CFUNC_DEF("getaddrinfo", 2, tjs_dns_getaddrinfo),
 #ifdef AI_PASSIVE
     TJS_CONST(AI_PASSIVE),
 #endif
@@ -159,12 +159,8 @@ static const JSCFunctionListEntry tjs_dns_funcs[] = {
 #endif
 };
 
-void tjs_mod_dns_init(JSContext *ctx, JSModuleDef *m) {
+void tjs__mod_dns_init(JSContext *ctx, JSValue ns) {
     JSValue obj = JS_NewObject(ctx);
     JS_SetPropertyFunctionList(ctx, obj, tjs_dns_funcs, countof(tjs_dns_funcs));
-    JS_SetModuleExport(ctx, m, "dns", obj);
-}
-
-void tjs_mod_dns_export(JSContext *ctx, JSModuleDef *m) {
-    JS_AddModuleExport(ctx, m, "dns");
+    JS_DefinePropertyValueStr(ctx, ns, "dns", obj, JS_PROP_C_W_E);
 }

--- a/src/error.c
+++ b/src/error.c
@@ -60,19 +60,15 @@ JSValue tjs_throw_errno(JSContext *ctx, int err) {
     return JS_Throw(ctx, obj);
 }
 
-static const JSCFunctionListEntry tjs_error_funcs[] = { JS_CFUNC_DEF("strerror", 1, tjs_error_strerror),
+static const JSCFunctionListEntry tjs_error_funcs[] = { TJS_CFUNC_DEF("strerror", 1, tjs_error_strerror),
 /* various errno values */
 #define DEF(x, s) JS_PROP_INT32_DEF(STRINGIFY(UV_##x), UV_##x, JS_PROP_CONFIGURABLE),
                                                         UV_ERRNO_MAP(DEF)
 #undef DEF
 };
 
-void tjs_mod_error_init(JSContext *ctx, JSModuleDef *m) {
+void tjs__mod_error_init(JSContext *ctx, JSValue ns) {
     JSValue obj = JS_NewCFunction2(ctx, tjs_error_constructor, "Error", 1, JS_CFUNC_constructor, 0);
     JS_SetPropertyFunctionList(ctx, obj, tjs_error_funcs, countof(tjs_error_funcs));
-    JS_SetModuleExport(ctx, m, "Error", obj);
-}
-
-void tjs_mod_error_export(JSContext *ctx, JSModuleDef *m) {
-    JS_AddModuleExport(ctx, m, "Error");
+    JS_DefinePropertyValueStr(ctx, ns, "Error", obj, JS_PROP_C_W_E);
 }

--- a/src/fs.c
+++ b/src/fs.c
@@ -798,19 +798,19 @@ static JSValue tjs_fs_readfile(JSContext *ctx, JSValueConst this_val, int argc, 
 static const JSCFunctionListEntry tjs_file_proto_funcs[] = {
     JS_CFUNC_MAGIC_DEF("read", 2, tjs_file_rw, 0),
     JS_CFUNC_MAGIC_DEF("write", 2, tjs_file_rw, 1),
-    JS_CFUNC_DEF("close", 0, tjs_file_close),
-    JS_CFUNC_DEF("fileno", 0, tjs_file_fileno),
-    JS_CFUNC_DEF("stat", 0, tjs_file_stat),
+    TJS_CFUNC_DEF("close", 0, tjs_file_close),
+    TJS_CFUNC_DEF("fileno", 0, tjs_file_fileno),
+    TJS_CFUNC_DEF("stat", 0, tjs_file_stat),
     JS_CGETSET_DEF("path", tjs_file_path_get, NULL),
     JS_PROP_STRING_DEF("[Symbol.toStringTag]", "File", JS_PROP_CONFIGURABLE),
 };
 
 static const JSCFunctionListEntry tjs_dir_proto_funcs[] = {
-    JS_CFUNC_DEF("close", 0, tjs_dir_close),
+    TJS_CFUNC_DEF("close", 0, tjs_dir_close),
     JS_CGETSET_DEF("path", tjs_dir_path_get, NULL),
-    JS_CFUNC_DEF("next", 0, tjs_dir_next),
+    TJS_CFUNC_DEF("next", 0, tjs_dir_next),
     JS_PROP_STRING_DEF("[Symbol.toStringTag]", "Dir", JS_PROP_CONFIGURABLE),
-    JS_CFUNC_DEF("[Symbol.asyncIterator]", 0, tjs_dir_iterator),
+    TJS_CFUNC_DEF("[Symbol.asyncIterator]", 0, tjs_dir_iterator),
 };
 
 static const JSCFunctionListEntry tjs_fs_funcs[] = {
@@ -841,21 +841,21 @@ static const JSCFunctionListEntry tjs_fs_funcs[] = {
 #ifdef S_ISUID
     TJS_CONST(S_ISUID),
 #endif
-    JS_CFUNC_DEF("open", 3, tjs_fs_open),
+    TJS_CFUNC_DEF("open", 3, tjs_fs_open),
     JS_CFUNC_MAGIC_DEF("stat", 1, tjs_fs_stat, 0),
     JS_CFUNC_MAGIC_DEF("lstat", 1, tjs_fs_stat, 1),
-    JS_CFUNC_DEF("realpath", 1, tjs_fs_realpath),
-    JS_CFUNC_DEF("unlink", 1, tjs_fs_unlink),
-    JS_CFUNC_DEF("rename", 2, tjs_fs_rename),
-    JS_CFUNC_DEF("mkdtemp", 1, tjs_fs_mkdtemp),
-    JS_CFUNC_DEF("mkstemp", 1, tjs_fs_mkstemp),
-    JS_CFUNC_DEF("rmdir", 1, tjs_fs_rmdir),
-    JS_CFUNC_DEF("copyfile", 3, tjs_fs_copyfile),
-    JS_CFUNC_DEF("readdir", 1, tjs_fs_readdir),
-    JS_CFUNC_DEF("readFile", 1, tjs_fs_readfile),
+    TJS_CFUNC_DEF("realpath", 1, tjs_fs_realpath),
+    TJS_CFUNC_DEF("unlink", 1, tjs_fs_unlink),
+    TJS_CFUNC_DEF("rename", 2, tjs_fs_rename),
+    TJS_CFUNC_DEF("mkdtemp", 1, tjs_fs_mkdtemp),
+    TJS_CFUNC_DEF("mkstemp", 1, tjs_fs_mkstemp),
+    TJS_CFUNC_DEF("rmdir", 1, tjs_fs_rmdir),
+    TJS_CFUNC_DEF("copyfile", 3, tjs_fs_copyfile),
+    TJS_CFUNC_DEF("readdir", 1, tjs_fs_readdir),
+    TJS_CFUNC_DEF("readFile", 1, tjs_fs_readfile),
 };
 
-void tjs_mod_fs_init(JSContext *ctx, JSModuleDef *m) {
+void tjs__mod_fs_init(JSContext *ctx, JSValue ns) {
     JSValue proto, obj;
 
     /* File object */
@@ -874,9 +874,5 @@ void tjs_mod_fs_init(JSContext *ctx, JSModuleDef *m) {
 
     obj = JS_NewObjectProto(ctx, JS_NULL);
     JS_SetPropertyFunctionList(ctx, obj, tjs_fs_funcs, countof(tjs_fs_funcs));
-    JS_SetModuleExport(ctx, m, "fs", obj);
-}
-
-void tjs_mod_fs_export(JSContext *ctx, JSModuleDef *m) {
-    JS_AddModuleExport(ctx, m, "fs");
+    JS_DefinePropertyValueStr(ctx, ns, "fs", obj, JS_PROP_C_W_E);
 }

--- a/src/js/bundle.js
+++ b/src/js/bundle.js
@@ -241,8 +241,8 @@ var require_engine_v8_version = __commonJS({
     var userAgent = require_engine_user_agent();
     var process2 = global2.process;
     var Deno = global2.Deno;
-    var versions2 = process2 && process2.versions || Deno && Deno.version;
-    var v8 = versions2 && versions2.v8;
+    var versions = process2 && process2.versions || Deno && Deno.version;
+    var v8 = versions && versions.v8;
     var match;
     var version;
     if (v8) {
@@ -4352,15 +4352,15 @@ var require_polyfill_es2018 = __commonJS({
         const resolvedPromise = promiseResolvedWith(void 0);
         return (fn) => PerformPromiseThen(resolvedPromise, fn);
       })();
-      function reflectCall(F2, V, args2) {
+      function reflectCall(F2, V, args) {
         if (typeof F2 !== "function") {
           throw new TypeError("Argument is not a function");
         }
-        return Function.prototype.apply.call(F2, V, args2);
+        return Function.prototype.apply.call(F2, V, args);
       }
-      function promiseCall(F2, V, args2) {
+      function promiseCall(F2, V, args) {
         try {
-          return promiseResolvedWith(reflectCall(F2, V, args2));
+          return promiseResolvedWith(reflectCall(F2, V, args));
         } catch (value) {
           return promiseRejectedWith(value);
         }
@@ -6465,7 +6465,7 @@ var require_polyfill_es2018 = __commonJS({
         return ctor;
       }
       const DOMException$1 = isDOMExceptionConstructor(NativeDOMException) ? NativeDOMException : createDOMExceptionPolyfill();
-      function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventCancel, signal2) {
+      function ReadableStreamPipeTo(source, dest, preventClose, preventAbort, preventCancel, signal) {
         const reader = AcquireReadableStreamDefaultReader(source);
         const writer = AcquireWritableStreamDefaultWriter(dest);
         source._disturbed = true;
@@ -6473,7 +6473,7 @@ var require_polyfill_es2018 = __commonJS({
         let currentWrite = promiseResolvedWith(void 0);
         return newPromise((resolve, reject) => {
           let abortAlgorithm;
-          if (signal2 !== void 0) {
+          if (signal !== void 0) {
             abortAlgorithm = () => {
               const error = new DOMException$1("Aborted", "AbortError");
               const actions = [];
@@ -6495,11 +6495,11 @@ var require_polyfill_es2018 = __commonJS({
               }
               shutdownWithAction(() => Promise.all(actions.map((action) => action())), true, error);
             };
-            if (signal2.aborted) {
+            if (signal.aborted) {
               abortAlgorithm();
               return;
             }
-            signal2.addEventListener("abort", abortAlgorithm);
+            signal.addEventListener("abort", abortAlgorithm);
           }
           function pipeLoop() {
             return newPromise((resolveLoop, rejectLoop) => {
@@ -6606,8 +6606,8 @@ var require_polyfill_es2018 = __commonJS({
           function finalize(isError, error) {
             WritableStreamDefaultWriterRelease(writer);
             ReadableStreamReaderGenericRelease(reader);
-            if (signal2 !== void 0) {
-              signal2.removeEventListener("abort", abortAlgorithm);
+            if (signal !== void 0) {
+              signal.removeEventListener("abort", abortAlgorithm);
             }
             if (isError) {
               reject(error);
@@ -7213,19 +7213,19 @@ var require_polyfill_es2018 = __commonJS({
         const preventAbort = options === null || options === void 0 ? void 0 : options.preventAbort;
         const preventCancel = options === null || options === void 0 ? void 0 : options.preventCancel;
         const preventClose = options === null || options === void 0 ? void 0 : options.preventClose;
-        const signal2 = options === null || options === void 0 ? void 0 : options.signal;
-        if (signal2 !== void 0) {
-          assertAbortSignal(signal2, `${context} has member 'signal' that`);
+        const signal = options === null || options === void 0 ? void 0 : options.signal;
+        if (signal !== void 0) {
+          assertAbortSignal(signal, `${context} has member 'signal' that`);
         }
         return {
           preventAbort: Boolean(preventAbort),
           preventCancel: Boolean(preventCancel),
           preventClose: Boolean(preventClose),
-          signal: signal2
+          signal
         };
       }
-      function assertAbortSignal(signal2, context) {
-        if (!isAbortSignal(signal2)) {
+      function assertAbortSignal(signal, context) {
+        if (!isAbortSignal(signal)) {
           throw new TypeError(`${context} is not an AbortSignal.`);
         }
       }
@@ -9719,20 +9719,20 @@ var require_implementation = __commonJS({
       if (typeof target !== "function" || toStr.call(target) !== funcType) {
         throw new TypeError(ERROR_MESSAGE + target);
       }
-      var args2 = slice.call(arguments, 1);
+      var args = slice.call(arguments, 1);
       var bound;
       var binder = function() {
         if (this instanceof bound) {
-          var result = target.apply(this, args2.concat(slice.call(arguments)));
+          var result = target.apply(this, args.concat(slice.call(arguments)));
           if (Object(result) === result) {
             return result;
           }
           return this;
         } else {
-          return target.apply(that, args2.concat(slice.call(arguments)));
+          return target.apply(that, args.concat(slice.call(arguments)));
         }
       };
-      var boundLength = Math.max(0, target.length - args2.length);
+      var boundLength = Math.max(0, target.length - args.length);
       var boundArgs = [];
       for (var i2 = 0; i2 < boundLength; i2++) {
         boundArgs.push("$" + i2);
@@ -10687,8 +10687,8 @@ var require_util = __commonJS({
         return objects.join(" ");
       }
       var i2 = 1;
-      var args2 = arguments;
-      var len = args2.length;
+      var args = arguments;
+      var len = args.length;
       var str = String(f2).replace(formatRegExp, function(x3) {
         if (x3 === "%%")
           return "%";
@@ -10696,12 +10696,12 @@ var require_util = __commonJS({
           return x3;
         switch (x3) {
           case "%s":
-            return String(args2[i2++]);
+            return String(args[i2++]);
           case "%d":
-            return Number(args2[i2++]);
+            return Number(args[i2++]);
           case "%j":
             try {
-              return JSON.stringify(args2[i2++]);
+              return JSON.stringify(args[i2++]);
             } catch (_) {
               return "[Circular]";
             }
@@ -10709,7 +10709,7 @@ var require_util = __commonJS({
             return x3;
         }
       });
-      for (var x2 = args2[i2]; i2 < len; x2 = args2[++i2]) {
+      for (var x2 = args[i2]; i2 < len; x2 = args[++i2]) {
         if (isNull(x2) || !isObject2(x2)) {
           str += " " + x2;
         } else {
@@ -11142,11 +11142,11 @@ var require_util = __commonJS({
           promiseResolve = resolve;
           promiseReject = reject;
         });
-        var args2 = [];
+        var args = [];
         for (var i2 = 0; i2 < arguments.length; i2++) {
-          args2.push(arguments[i2]);
+          args.push(arguments[i2]);
         }
-        args2.push(function(err, value) {
+        args.push(function(err, value) {
           if (err) {
             promiseReject(err);
           } else {
@@ -11154,7 +11154,7 @@ var require_util = __commonJS({
           }
         });
         try {
-          original.apply(this, args2);
+          original.apply(this, args);
         } catch (err) {
           promiseReject(err);
         }
@@ -11184,11 +11184,11 @@ var require_util = __commonJS({
         throw new TypeError('The "original" argument must be of type Function');
       }
       function callbackified() {
-        var args2 = [];
+        var args = [];
         for (var i2 = 0; i2 < arguments.length; i2++) {
-          args2.push(arguments[i2]);
+          args.push(arguments[i2]);
         }
-        var maybeCb = args2.pop();
+        var maybeCb = args.pop();
         if (typeof maybeCb !== "function") {
           throw new TypeError("The last argument must be of type Function");
         }
@@ -11196,7 +11196,7 @@ var require_util = __commonJS({
         var cb = function() {
           return maybeCb.apply(self2, arguments);
         };
-        original.apply(this, args2).then(function(ret) {
+        original.apply(this, args).then(function(ret) {
           process.nextTick(cb.bind(null, null, ret));
         }, function(rej) {
           process.nextTick(callbackifyOnRejected.bind(null, rej, cb));
@@ -11212,7 +11212,7 @@ var require_util = __commonJS({
 
 // polyfills/base.js
 var import_queue_microtask = __toESM(require_queue_microtask());
-import * as core from "@tjs/core";
+var core = globalThis.__bootstrap;
 globalThis.setTimeout = core.setTimeout;
 globalThis.clearTimeout = core.clearTimeout;
 globalThis.setInterval = core.setInterval;
@@ -12288,7 +12288,7 @@ var U = function() {
 window.URLPattern = U;
 
 // polyfills/xhr.js
-import { XMLHttpRequest as XHR } from "@tjs/core";
+var { XMLHttpRequest: XHR } = globalThis.__bootstrap;
 var kXHR = Symbol("kXHR");
 var XMLHttpRequest2 = class extends EventTarget {
   constructor() {
@@ -12373,8 +12373,8 @@ var XMLHttpRequest2 = class extends EventTarget {
   getResponseHeader(name) {
     return this[kXHR].getResponseHeader(name);
   }
-  open(...args2) {
-    return this[kXHR].open(...args2);
+  open(...args) {
+    return this[kXHR].open(...args);
   }
   overrideMimeType(mimeType) {
     return this[kXHR].overrideMimeType(mimeType);
@@ -12704,18 +12704,18 @@ var import_whatwg_fetch = __toESM(require_fetch_umd());
     var Request = NativeRequest;
     if (Request && !Request.prototype.hasOwnProperty("signal") || __FORCE_INSTALL_ABORTCONTROLLER_POLYFILL) {
       Request = function Request2(input, init) {
-        var signal2;
+        var signal;
         if (init && init.signal) {
-          signal2 = init.signal;
+          signal = init.signal;
           delete init.signal;
         }
         var request = new NativeRequest(input, init);
-        if (signal2) {
+        if (signal) {
           Object.defineProperty(request, "signal", {
             writable: false,
             enumerable: false,
             configurable: true,
-            value: signal2
+            value: signal
           });
         }
         return request;
@@ -12724,8 +12724,8 @@ var import_whatwg_fetch = __toESM(require_fetch_umd());
     }
     var realFetch = fetch;
     var abortableFetch = function abortableFetch2(input, init) {
-      var signal2 = Request && Request.prototype.isPrototypeOf(input) ? input.signal : init ? init.signal : void 0;
-      if (signal2) {
+      var signal = Request && Request.prototype.isPrototypeOf(input) ? input.signal : init ? init.signal : void 0;
+      if (signal) {
         var abortError;
         try {
           abortError = new DOMException("Aborted", "AbortError");
@@ -12733,11 +12733,11 @@ var import_whatwg_fetch = __toESM(require_fetch_umd());
           abortError = new Error("Aborted");
           abortError.name = "AbortError";
         }
-        if (signal2.aborted) {
+        if (signal.aborted) {
           return Promise.reject(abortError);
         }
         var cancellation = new Promise(function(_, reject) {
-          signal2.addEventListener("abort", function() {
+          signal.addEventListener("abort", function() {
             return reject(abortError);
           }, {
             once: true
@@ -12924,21 +12924,21 @@ ${tableChars.leftMiddle}${divider.join(tableChars.rowMiddle)}${tableChars.rightM
   return result;
 }
 var Console = class {
-  log(...args2) {
-    print(...args2);
+  log(...args) {
+    print(...args);
   }
-  info(...args2) {
-    print(...args2);
+  info(...args) {
+    print(...args);
   }
-  warn(...args2) {
-    print(...args2);
+  warn(...args) {
+    print(...args);
   }
-  error(...args2) {
-    print(...args2);
+  error(...args) {
+    print(...args);
   }
-  assert(expression, ...args2) {
+  assert(expression, ...args) {
     if (!expression) {
-      this.error(...args2);
+      this.error(...args);
     }
   }
   dir(o2) {
@@ -13011,10 +13011,10 @@ var Console = class {
     const body = [indexKeys, ...bodyValues, values];
     toTable(header, body);
   }
-  trace(...args2) {
+  trace(...args) {
     const err = new Error();
     err.name = "Trace";
-    err.message = args2.map(String).join(" ");
+    err.message = args.map(String).join(" ");
     const tmpStack = err.stack.split("\n");
     tmpStack.splice(0, 1);
     err.stack = tmpStack.join("\n");
@@ -13027,9 +13027,6 @@ Object.defineProperty(window, "console", {
   writable: true,
   value: new Console()
 });
-
-// polyfills/crypto.js
-import * as core2 from "@tjs/core";
 
 // node_modules/uuid/dist/esm-browser/rng.js
 var getRandomValues;
@@ -13087,6 +13084,7 @@ function v4(options, buf, offset) {
 var v4_default = v4;
 
 // polyfills/crypto.js
+var core2 = globalThis.__bootstrap;
 var TypedArrayPrototype = Object.getPrototypeOf(Uint8Array.prototype);
 var TypedArrayProto_toStringTag = Object.getOwnPropertyDescriptor(TypedArrayPrototype, Symbol.toStringTag).get;
 function getRandomValues2(obj) {
@@ -13126,7 +13124,7 @@ Object.defineProperty(window, "crypto", {
 });
 
 // polyfills/performance.js
-import { hrtimeMs } from "@tjs/core";
+var { hrtimeMs } = globalThis.__bootstrap;
 var Performance = class {
   constructor() {
     this._startTime = hrtimeMs();
@@ -13208,7 +13206,7 @@ Object.defineProperty(window, "performance", {
 });
 
 // polyfills/wasm.js
-import { wasm } from "@tjs/core";
+var { wasm } = globalThis.__bootstrap;
 var kWasmModule = Symbol("kWasmModule");
 var kWasmModuleRef = Symbol("kWasmModuleRef");
 var kWasmExports = Symbol("kWasmExports");
@@ -13218,20 +13216,20 @@ var kWasiLinked = Symbol("kWasiLinked");
 var kWasiStarted = Symbol("kWasiStarted");
 var kWasiOptions = Symbol("kWasiOptions");
 var CompileError = class extends Error {
-  constructor(...args2) {
-    super(...args2);
+  constructor(...args) {
+    super(...args);
     this.name = "CompileError";
   }
 };
 var LinkError = class extends Error {
-  constructor(...args2) {
-    super(...args2);
+  constructor(...args) {
+    super(...args);
     this.name = "LinkError";
   }
 };
 var RuntimeError = class extends Error {
-  constructor(...args2) {
-    super(...args2);
+  constructor(...args) {
+    super(...args);
     this.name = "RuntimeError";
   }
 };
@@ -13247,10 +13245,10 @@ function getWasmError(e2) {
       return new TypeError(`Invalid WASM error: ${e2.wasmError}`);
   }
 }
-function callWasmFunction(name, ...args2) {
+function callWasmFunction(name, ...args) {
   const instance = this;
   try {
-    return instance.callFunction(name, ...args2);
+    return instance.callFunction(name, ...args);
   } catch (e2) {
     if (e2.wasmError) {
       throw getWasmError(e2);
@@ -13376,7 +13374,7 @@ Object.defineProperty(globalThis, "WebAssembly", {
 });
 
 // polyfills/worker.js
-import { Worker as _Worker } from "@tjs/core";
+var { Worker: _Worker } = globalThis.__bootstrap;
 var kWorker = Symbol("kWorker");
 var Worker = class extends EventTarget {
   constructor(path) {
@@ -13393,8 +13391,8 @@ var Worker = class extends EventTarget {
     };
     this[kWorker] = worker;
   }
-  postMessage(...args2) {
-    this[kWorker].postMessage(args2);
+  postMessage(...args) {
+    this[kWorker].postMessage(args);
   }
   terminate() {
     this[kWorker].terminate();
@@ -13411,11 +13409,8 @@ Object.defineProperty(window, "Worker", {
   value: Worker
 });
 
-// tjs/index.js
-import * as core4 from "@tjs/core";
-
 // tjs/stdio.js
-import * as core3 from "@tjs/core";
+var core3 = globalThis.__bootstrap;
 var kStdioHandle = Symbol("kStdioHandle");
 var kStdioHandleType = Symbol("kStdioHandleType");
 var BaseIOStream = class {
@@ -13485,6 +13480,7 @@ function createStderr() {
 }
 
 // tjs/index.js
+var core4 = globalThis.__bootstrap;
 var tjs2 = /* @__PURE__ */ Object.create(null);
 var noExport = [
   "setTimeout",
@@ -13492,8 +13488,6 @@ var noExport = [
   "clearTimeout",
   "clearInterval",
   "guessHandleType",
-  "alert",
-  "prompt",
   "XMLHttpRequest",
   "Worker",
   "signal",
@@ -13504,7 +13498,7 @@ var noExport = [
 ];
 tjs2.signal = core4.signal;
 for (const [key, value] of Object.entries(core4)) {
-  if (noExport.indexOf(key) !== -1) {
+  if (noExport.includes(key)) {
     continue;
   }
   if (key.startsWith("SIG")) {

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "postinstall": "patch-package",
-    "bundle": "esbuild index.js --bundle --outfile=bundle.js --target=es2020 --platform=neutral --format=esm --external:'@tjs/core' --main-fields=main,module",
+    "bundle": "esbuild index.js --bundle --outfile=bundle.js --target=es2020 --platform=neutral --format=esm --main-fields=main,module",
     "stdlib": "esbuild stdlib/index.js --bundle --outfile=std.js --target=es2020 --platform=neutral --format=esm --main-fields=main,module"
   },
   "author": "",

--- a/src/js/polyfills/base.js
+++ b/src/js/polyfills/base.js
@@ -1,4 +1,5 @@
-import * as core from '@tjs/core';
+const core = globalThis.__bootstrap;
+
 import queueMicrotask from 'queue-microtask';
 
 globalThis.setTimeout = core.setTimeout;

--- a/src/js/polyfills/crypto.js
+++ b/src/js/polyfills/crypto.js
@@ -1,4 +1,5 @@
-import * as core from '@tjs/core';
+const core = globalThis.__bootstrap;
+
 import { v4 } from 'uuid';
 
 const TypedArrayPrototype = Object.getPrototypeOf(Uint8Array.prototype);

--- a/src/js/polyfills/performance.js
+++ b/src/js/polyfills/performance.js
@@ -1,4 +1,4 @@
-import { hrtimeMs } from '@tjs/core';
+const { hrtimeMs } = globalThis.__bootstrap;
 
 // https://www.w3.org/TR/user-timing/
 // Derived from: https://github.com/blackswanny/performance-polyfill

--- a/src/js/polyfills/wasm.js
+++ b/src/js/polyfills/wasm.js
@@ -1,4 +1,4 @@
-import { wasm } from '@tjs/core';
+const { wasm } = globalThis.__bootstrap;
 
 const kWasmModule = Symbol('kWasmModule');
 const kWasmModuleRef = Symbol('kWasmModuleRef');

--- a/src/js/polyfills/worker.js
+++ b/src/js/polyfills/worker.js
@@ -1,4 +1,5 @@
-import { Worker as _Worker } from '@tjs/core';
+const { Worker: _Worker } = globalThis.__bootstrap;
+
 import { defineEventAttribute } from './event-target';
 
 const kWorker = Symbol('kWorker');

--- a/src/js/polyfills/xhr.js
+++ b/src/js/polyfills/xhr.js
@@ -1,4 +1,5 @@
-import { XMLHttpRequest as XHR } from '@tjs/core';
+const { XMLHttpRequest: XHR } = globalThis.__bootstrap;
+
 import { defineEventAttribute } from './event-target.js';
 
 const kXHR = Symbol('kXHR');

--- a/src/js/tjs/index.js
+++ b/src/js/tjs/index.js
@@ -1,4 +1,5 @@
-import * as core from '@tjs/core';
+const core = globalThis.__bootstrap;
+
 import { createStdin, createStdout, createStderr } from './stdio.js';
 
 // The "tjs" global.
@@ -11,8 +12,6 @@ const noExport = [
     'clearTimeout',
     'clearInterval',
     'guessHandleType',
-    'alert',
-    'prompt',
     'XMLHttpRequest',
     'Worker',
     'signal',
@@ -25,7 +24,7 @@ const noExport = [
 tjs.signal = core.signal;
 
 for (const [key, value] of Object.entries(core)) {
-    if (noExport.indexOf(key) !== -1) {
+    if (noExport.includes(key)) {
         continue;
     }
 

--- a/src/js/tjs/stdio.js
+++ b/src/js/tjs/stdio.js
@@ -1,4 +1,4 @@
-import * as core from '@tjs/core';
+const core = globalThis.__bootstrap;
 
 const kStdioHandle = Symbol('kStdioHandle');
 const kStdioHandleType = Symbol('kStdioHandleType');

--- a/src/js/worker-bootstrap.js
+++ b/src/js/worker-bootstrap.js
@@ -1,4 +1,4 @@
-// `workerThis` is a reference to a tjs/core `Worker` objet.
+// `workerThis` is a reference to a in internal `Worker` objet.
 
 const kWorkerSelf = Symbol('kWorkerSelf');
 

--- a/src/misc.c
+++ b/src/misc.c
@@ -310,43 +310,32 @@ static const JSCFunctionListEntry tjs_misc_funcs[] = {
     TJS_CONST(STDIN_FILENO),
     TJS_CONST(STDOUT_FILENO),
     TJS_CONST(STDERR_FILENO),
-    JS_CFUNC_DEF("hrtime", 0, tjs_hrtime),
-    JS_CFUNC_DEF("hrtimeMs", 0, tjs_hrtime_ms),
-    JS_CFUNC_DEF("gettimeofday", 0, tjs_gettimeofday),
-    JS_CFUNC_DEF("uname", 0, tjs_uname),
-    JS_CFUNC_DEF("guessHandle", 1, tjs_guess_handle),
-    JS_CFUNC_DEF("environ", 0, tjs_environ),
-    JS_CFUNC_DEF("getenv", 0, tjs_getenv),
-    JS_CFUNC_DEF("setenv", 2, tjs_setenv),
-    JS_CFUNC_DEF("unsetenv", 1, tjs_unsetenv),
-    JS_CFUNC_DEF("cwd", 0, tjs_cwd),
-    JS_CFUNC_DEF("homedir", 0, tjs_homedir),
-    JS_CFUNC_DEF("tmpdir", 0, tjs_tmpdir),
-    JS_CFUNC_DEF("exepath", 0, tjs_exepath),
-    JS_CFUNC_DEF("random", 3, tjs_random),
+    TJS_CFUNC_DEF("hrtime", 0, tjs_hrtime),
+    TJS_CFUNC_DEF("hrtimeMs", 0, tjs_hrtime_ms),
+    TJS_CFUNC_DEF("gettimeofday", 0, tjs_gettimeofday),
+    TJS_CFUNC_DEF("uname", 0, tjs_uname),
+    TJS_CFUNC_DEF("guessHandle", 1, tjs_guess_handle),
+    TJS_CFUNC_DEF("environ", 0, tjs_environ),
+    TJS_CFUNC_DEF("getenv", 0, tjs_getenv),
+    TJS_CFUNC_DEF("setenv", 2, tjs_setenv),
+    TJS_CFUNC_DEF("unsetenv", 1, tjs_unsetenv),
+    TJS_CFUNC_DEF("cwd", 0, tjs_cwd),
+    TJS_CFUNC_DEF("homedir", 0, tjs_homedir),
+    TJS_CFUNC_DEF("tmpdir", 0, tjs_tmpdir),
+    TJS_CFUNC_DEF("exepath", 0, tjs_exepath),
+    TJS_CFUNC_DEF("random", 3, tjs_random),
 };
 
-void tjs_mod_misc_init(JSContext *ctx, JSModuleDef *m) {
-    JS_SetModuleExportList(ctx, m, tjs_misc_funcs, countof(tjs_misc_funcs));
-
-    JS_SetModuleExport(ctx, m, "args", tjs__get_args(ctx));
-
-    JS_SetModuleExport(ctx, m, "platform", JS_NewString(ctx, TJS__PLATFORM));
-
-    JS_SetModuleExport(ctx, m, "version", JS_NewString(ctx, tjs_version()));
+void tjs__mod_misc_init(JSContext *ctx, JSValue ns) {
+    JS_SetPropertyFunctionList(ctx, ns, tjs_misc_funcs, countof(tjs_misc_funcs));
+    JS_DefinePropertyValueStr(ctx, ns, "args", tjs__get_args(ctx), JS_PROP_C_W_E);
+    JS_DefinePropertyValueStr(ctx, ns, "platform", JS_NewString(ctx, TJS__PLATFORM), JS_PROP_C_W_E);
+    JS_DefinePropertyValueStr(ctx, ns, "version", JS_NewString(ctx, tjs_version()), JS_PROP_C_W_E);
     JSValue versions = JS_NewObjectProto(ctx, JS_NULL);
     JS_DefinePropertyValueStr(ctx, versions, "quickjs", JS_NewString(ctx, QJS_VERSION_STR), JS_PROP_C_W_E);
     JS_DefinePropertyValueStr(ctx, versions, "tjs", JS_NewString(ctx, tjs_version()), JS_PROP_C_W_E);
     JS_DefinePropertyValueStr(ctx, versions, "uv", JS_NewString(ctx, uv_version_string()), JS_PROP_C_W_E);
     JS_DefinePropertyValueStr(ctx, versions, "curl", JS_NewString(ctx, curl_version()), JS_PROP_C_W_E);
     JS_DefinePropertyValueStr(ctx, versions, "wasm3", JS_NewString(ctx, M3_VERSION), JS_PROP_C_W_E);
-    JS_SetModuleExport(ctx, m, "versions", versions);
-}
-
-void tjs_mod_misc_export(JSContext *ctx, JSModuleDef *m) {
-    JS_AddModuleExportList(ctx, m, tjs_misc_funcs, countof(tjs_misc_funcs));
-    JS_AddModuleExport(ctx, m, "args");
-    JS_AddModuleExport(ctx, m, "platform");
-    JS_AddModuleExport(ctx, m, "version");
-    JS_AddModuleExport(ctx, m, "versions");
+    JS_DefinePropertyValueStr(ctx, ns, "versions", versions, JS_PROP_C_W_E);
 }

--- a/src/modules.c
+++ b/src/modules.c
@@ -178,24 +178,10 @@ int js_module_set_import_meta(JSContext *ctx, JSValueConst func_val, JS_BOOL use
 #endif
 
 char *tjs_module_normalizer(JSContext *ctx, const char *base_name, const char *name, void *opaque) {
-    static char *internal_modules[] = {
-        "@tjs/core"
-    };
-
     TJSRuntime *qrt = opaque;
     CHECK_NOT_NULL(qrt);
 
     // printf("normalize: %s %s\n", base_name, name);
-
-    if (!qrt->in_bootstrap && name[0] == '@') {
-        /* check if it's an internal module, those cannot be imported */
-        for (int i = 0; i < ARRAY_SIZE(internal_modules); i++) {
-            if (strncmp(internal_modules[i], name, strlen(internal_modules[i])) == 0) {
-                JS_ThrowReferenceError(ctx, "could not load '%s', it's an internal module", name);
-                return NULL;
-            }
-        }
-    }
 
     char *filename, *p;
     const char *r;

--- a/src/os.c
+++ b/src/os.c
@@ -127,18 +127,13 @@ static JSValue tjs_network_interfaces(JSContext *ctx, JSValueConst this_val, int
 }
 
 static const JSCFunctionListEntry tjs_os_funcs[] = {
-    JS_CFUNC_DEF("cpuInfo", 0, tjs_cpu_info),
-    JS_CFUNC_DEF("loadavg", 0, tjs_loadavg),
-    JS_CFUNC_DEF("networkInterfaces", 0, tjs_network_interfaces),
+    TJS_CFUNC_DEF("cpuInfo", 0, tjs_cpu_info),
+    TJS_CFUNC_DEF("loadavg", 0, tjs_loadavg),
+    TJS_CFUNC_DEF("networkInterfaces", 0, tjs_network_interfaces),
 };
 
-void tjs_mod_os_init(JSContext *ctx, JSModuleDef *m) {
+void tjs__mod_os_init(JSContext *ctx, JSValue ns) {
     JSValue obj = JS_NewObjectProto(ctx, JS_NULL);
     JS_SetPropertyFunctionList(ctx, obj, tjs_os_funcs, countof(tjs_os_funcs));
-    JS_SetModuleExport(ctx, m, "os", obj);
+    JS_DefinePropertyValueStr(ctx, ns, "os", obj, JS_PROP_C_W_E);
 }
-
-void tjs_mod_os_export(JSContext *ctx, JSModuleDef *m) {
-    JS_AddModuleExport(ctx, m, "os");
-}
-

--- a/src/private.h
+++ b/src/private.h
@@ -48,7 +48,6 @@ struct TJSRuntime {
     } jobs;
     uv_async_t stop;
     bool is_worker;
-    bool in_bootstrap;
     struct {
         CURLM *curlm_h;
         uv_timer_t timer;
@@ -61,34 +60,20 @@ struct TJSRuntime {
     } builtins;
 };
 
-void tjs_mod_dns_init(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_dns_export(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_error_init(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_error_export(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_fs_init(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_fs_export(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_misc_init(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_misc_export(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_os_init(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_os_export(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_process_init(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_process_export(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_signals_init(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_signals_export(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_std_init(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_std_export(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_streams_init(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_streams_export(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_timers_init(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_timers_export(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_udp_init(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_udp_export(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_wasm_init(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_wasm_export(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_worker_init(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_worker_export(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_xhr_init(JSContext *ctx, JSModuleDef *m);
-void tjs_mod_xhr_export(JSContext *ctx, JSModuleDef *m);
+void tjs__mod_dns_init(JSContext *ctx, JSValue ns);
+void tjs__mod_error_init(JSContext *ctx, JSValue ns);
+void tjs__mod_fs_init(JSContext *ctx, JSValue ns);
+void tjs__mod_misc_init(JSContext *ctx, JSValue ns);
+void tjs__mod_os_init(JSContext *ctx, JSValue ns);
+void tjs__mod_process_init(JSContext *ctx, JSValue ns);
+void tjs__mod_signals_init(JSContext *ctx, JSValue ns);
+void tjs__mod_std_init(JSContext *ctx, JSValue ns);
+void tjs__mod_streams_init(JSContext *ctx, JSValue ns);
+void tjs__mod_timers_init(JSContext *ctx, JSValue ns);
+void tjs__mod_udp_init(JSContext *ctx, JSValue ns);
+void tjs__mod_wasm_init(JSContext *ctx, JSValue ns);
+void tjs__mod_worker_init(JSContext *ctx, JSValue ns);
+void tjs__mod_xhr_init(JSContext *ctx, JSValue ns);
 
 JSValue tjs_new_error(JSContext *ctx, int err);
 JSValue tjs_throw_errno(JSContext *ctx, int err);

--- a/src/process.c
+++ b/src/process.c
@@ -403,8 +403,8 @@ cleanup:
 }
 
 static const JSCFunctionListEntry tjs_process_proto_funcs[] = {
-    JS_CFUNC_DEF("kill", 1, tjs_process_kill),
-    JS_CFUNC_DEF("wait", 0, tjs_process_wait),
+    TJS_CFUNC_DEF("kill", 1, tjs_process_kill),
+    TJS_CFUNC_DEF("wait", 0, tjs_process_wait),
     JS_CGETSET_DEF("pid", tjs_process_pid_get, NULL),
     JS_CGETSET_MAGIC_DEF("stdin", tjs_process_stdio_get, NULL, 0),
     JS_CGETSET_MAGIC_DEF("stdout", tjs_process_stdio_get, NULL, 1),
@@ -413,19 +413,15 @@ static const JSCFunctionListEntry tjs_process_proto_funcs[] = {
 };
 
 static const JSCFunctionListEntry tjs_process_funcs[] = {
-    JS_CFUNC_DEF("spawn", 2, tjs_spawn),
+    TJS_CFUNC_DEF("spawn", 2, tjs_spawn),
 };
 
-void tjs_mod_process_init(JSContext *ctx, JSModuleDef *m) {
+void tjs__mod_process_init(JSContext *ctx, JSValue ns) {
     JS_NewClassID(&tjs_process_class_id);
     JS_NewClass(JS_GetRuntime(ctx), tjs_process_class_id, &tjs_process_class);
     JSValue proto = JS_NewObject(ctx);
     JS_SetPropertyFunctionList(ctx, proto, tjs_process_proto_funcs, countof(tjs_process_proto_funcs));
     JS_SetClassProto(ctx, tjs_process_class_id, proto);
 
-    JS_SetModuleExportList(ctx, m, tjs_process_funcs, countof(tjs_process_funcs));
-}
-
-void tjs_mod_process_export(JSContext *ctx, JSModuleDef *m) {
-    JS_AddModuleExportList(ctx, m, tjs_process_funcs, countof(tjs_process_funcs));
+    JS_SetPropertyFunctionList(ctx, ns, tjs_process_funcs, countof(tjs_process_funcs));
 }

--- a/src/signals.c
+++ b/src/signals.c
@@ -146,7 +146,7 @@ static JSValue tjs_signal_handler_signum_get(JSContext *ctx, JSValueConst this_v
 }
 
 static const JSCFunctionListEntry tjs_signal_handler_proto_funcs[] = {
-    JS_CFUNC_DEF("close", 0, tjs_signal_handler_close),
+    TJS_CFUNC_DEF("close", 0, tjs_signal_handler_close),
     JS_CGETSET_DEF("signum", tjs_signal_handler_signum_get, NULL),
     JS_PROP_STRING_DEF("[Symbol.toStringTag]", "Signal Handler", JS_PROP_CONFIGURABLE),
 };
@@ -261,18 +261,15 @@ static const JSCFunctionListEntry tjs_signal_funcs[] = {
 #ifdef SIGUNUSED
     TJS_CONST(SIGUNUSED),
 #endif
-    JS_CFUNC_DEF("signal", 2, tjs_signal),
+    TJS_CFUNC_DEF("signal", 2, tjs_signal),
 };
 
-void tjs_mod_signals_init(JSContext *ctx, JSModuleDef *m) {
+void tjs__mod_signals_init(JSContext *ctx, JSValue ns) {
     JS_NewClassID(&tjs_signal_handler_class_id);
     JS_NewClass(JS_GetRuntime(ctx), tjs_signal_handler_class_id, &tjs_signal_handler_class);
     JSValue proto = JS_NewObject(ctx);
     JS_SetPropertyFunctionList(ctx, proto, tjs_signal_handler_proto_funcs, countof(tjs_signal_handler_proto_funcs));
     JS_SetClassProto(ctx, tjs_signal_handler_class_id, proto);
-    JS_SetModuleExportList(ctx, m, tjs_signal_funcs, countof(tjs_signal_funcs));
-}
 
-void tjs_mod_signals_export(JSContext *ctx, JSModuleDef *m) {
-    JS_AddModuleExportList(ctx, m, tjs_signal_funcs, countof(tjs_signal_funcs));
+    JS_SetPropertyFunctionList(ctx, ns, tjs_signal_funcs, countof(tjs_signal_funcs));
 }

--- a/src/std.c
+++ b/src/std.c
@@ -69,16 +69,12 @@ static JSValue js_evalScript(JSContext *ctx, JSValueConst this_val, int argc, JS
 }
 
 static const JSCFunctionListEntry js_std_funcs[] = {
-    JS_CFUNC_DEF("exit", 1, js_std_exit),
-    JS_CFUNC_DEF("gc", 0, js_std_gc),
-    JS_CFUNC_DEF("evalScript", 1, js_evalScript),
-    JS_CFUNC_DEF("loadScript", 1, js_loadScript),
+    TJS_CFUNC_DEF("exit", 1, js_std_exit),
+    TJS_CFUNC_DEF("gc", 0, js_std_gc),
+    TJS_CFUNC_DEF("evalScript", 1, js_evalScript),
+    TJS_CFUNC_DEF("loadScript", 1, js_loadScript),
 };
 
-void tjs_mod_std_init(JSContext *ctx, JSModuleDef *m) {
-    JS_SetModuleExportList(ctx, m, js_std_funcs, countof(js_std_funcs));
-}
-
-void tjs_mod_std_export(JSContext *ctx, JSModuleDef *m) {
-    JS_AddModuleExportList(ctx, m, js_std_funcs, countof(js_std_funcs));
+void tjs__mod_std_init(JSContext *ctx, JSValue ns) {
+    JS_SetPropertyFunctionList(ctx, ns, js_std_funcs, countof(js_std_funcs));
 }

--- a/src/streams.c
+++ b/src/streams.c
@@ -850,18 +850,18 @@ static JSValue tjs_pipe_accept(JSContext *ctx, JSValueConst this_val, int argc, 
 
 static const JSCFunctionListEntry tjs_tcp_proto_funcs[] = {
     /* Stream functions */
-    JS_CFUNC_DEF("close", 0, tjs_tcp_close),
-    JS_CFUNC_DEF("read", 1, tjs_tcp_read),
-    JS_CFUNC_DEF("write", 1, tjs_tcp_write),
-    JS_CFUNC_DEF("shutdown", 0, tjs_tcp_shutdown),
-    JS_CFUNC_DEF("fileno", 0, tjs_tcp_fileno),
-    JS_CFUNC_DEF("listen", 1, tjs_tcp_listen),
-    JS_CFUNC_DEF("accept", 0, tjs_tcp_accept),
+    TJS_CFUNC_DEF("close", 0, tjs_tcp_close),
+    TJS_CFUNC_DEF("read", 1, tjs_tcp_read),
+    TJS_CFUNC_DEF("write", 1, tjs_tcp_write),
+    TJS_CFUNC_DEF("shutdown", 0, tjs_tcp_shutdown),
+    TJS_CFUNC_DEF("fileno", 0, tjs_tcp_fileno),
+    TJS_CFUNC_DEF("listen", 1, tjs_tcp_listen),
+    TJS_CFUNC_DEF("accept", 0, tjs_tcp_accept),
     /* TCP functions */
     JS_CFUNC_MAGIC_DEF("getsockname", 0, tjs_tcp_getsockpeername, 0),
     JS_CFUNC_MAGIC_DEF("getpeername", 0, tjs_tcp_getsockpeername, 1),
-    JS_CFUNC_DEF("connect", 1, tjs_tcp_connect),
-    JS_CFUNC_DEF("bind", 1, tjs_tcp_bind),
+    TJS_CFUNC_DEF("connect", 1, tjs_tcp_connect),
+    TJS_CFUNC_DEF("bind", 1, tjs_tcp_bind),
     JS_PROP_STRING_DEF("[Symbol.toStringTag]", "TCP", JS_PROP_CONFIGURABLE),
 };
 
@@ -871,40 +871,40 @@ static const JSCFunctionListEntry tjs_tcp_class_funcs[] = {
 
 static const JSCFunctionListEntry tjs_tty_proto_funcs[] = {
     /* Stream functions */
-    JS_CFUNC_DEF("close", 0, tjs_tty_close),
-    JS_CFUNC_DEF("read", 1, tjs_tty_read),
-    JS_CFUNC_DEF("write", 1, tjs_tty_write),
-    JS_CFUNC_DEF("fileno", 0, tjs_tty_fileno),
+    TJS_CFUNC_DEF("close", 0, tjs_tty_close),
+    TJS_CFUNC_DEF("read", 1, tjs_tty_read),
+    TJS_CFUNC_DEF("write", 1, tjs_tty_write),
+    TJS_CFUNC_DEF("fileno", 0, tjs_tty_fileno),
     /* TTY functions */
-    JS_CFUNC_DEF("setMode", 1, tjs_tty_setMode),
-    JS_CFUNC_DEF("getWinSize", 0, tjs_tty_getWinSize),
+    TJS_CFUNC_DEF("setMode", 1, tjs_tty_setMode),
+    TJS_CFUNC_DEF("getWinSize", 0, tjs_tty_getWinSize),
     JS_PROP_STRING_DEF("[Symbol.toStringTag]", "TTY", JS_PROP_CONFIGURABLE),
 };
 
 static const JSCFunctionListEntry tjs_tty_class_funcs[] = {
-    JS_PROP_INT32_DEF("MODE_NORMAL", UV_TTY_MODE_NORMAL, 0),
-    JS_PROP_INT32_DEF("MODE_RAW", UV_TTY_MODE_RAW, 0),
-    JS_PROP_INT32_DEF("MODE_IO", UV_TTY_MODE_IO, 0),
+    TJS_CONST2("MODE_NORMAL", UV_TTY_MODE_NORMAL),
+    TJS_CONST2("MODE_RAW", UV_TTY_MODE_RAW),
+    TJS_CONST2("MODE_IO", UV_TTY_MODE_IO),
 };
 
 static const JSCFunctionListEntry tjs_pipe_proto_funcs[] = {
     /* Stream functions */
-    JS_CFUNC_DEF("close", 0, tjs_pipe_close),
-    JS_CFUNC_DEF("read", 1, tjs_pipe_read),
-    JS_CFUNC_DEF("write", 1, tjs_pipe_write),
-    JS_CFUNC_DEF("fileno", 0, tjs_pipe_fileno),
-    JS_CFUNC_DEF("listen", 1, tjs_pipe_listen),
-    JS_CFUNC_DEF("accept", 0, tjs_pipe_accept),
-    JS_CFUNC_DEF("open", 1, tjs_pipe_open),
+    TJS_CFUNC_DEF("close", 0, tjs_pipe_close),
+    TJS_CFUNC_DEF("read", 1, tjs_pipe_read),
+    TJS_CFUNC_DEF("write", 1, tjs_pipe_write),
+    TJS_CFUNC_DEF("fileno", 0, tjs_pipe_fileno),
+    TJS_CFUNC_DEF("listen", 1, tjs_pipe_listen),
+    TJS_CFUNC_DEF("accept", 0, tjs_pipe_accept),
+    TJS_CFUNC_DEF("open", 1, tjs_pipe_open),
     /* Pipe functions */
     JS_CFUNC_MAGIC_DEF("getsockname", 0, tjs_pipe_getsockpeername, 0),
     JS_CFUNC_MAGIC_DEF("getpeername", 0, tjs_pipe_getsockpeername, 1),
-    JS_CFUNC_DEF("connect", 1, tjs_pipe_connect),
-    JS_CFUNC_DEF("bind", 1, tjs_pipe_bind),
+    TJS_CFUNC_DEF("connect", 1, tjs_pipe_connect),
+    TJS_CFUNC_DEF("bind", 1, tjs_pipe_bind),
     JS_PROP_STRING_DEF("[Symbol.toStringTag]", "Pipe", JS_PROP_CONFIGURABLE),
 };
 
-void tjs_mod_streams_init(JSContext *ctx, JSModuleDef *m) {
+void tjs__mod_streams_init(JSContext *ctx, JSValue ns) {
     JSValue proto, obj;
 
     /* TCP class */
@@ -917,7 +917,7 @@ void tjs_mod_streams_init(JSContext *ctx, JSModuleDef *m) {
     /* TCP object */
     obj = JS_NewCFunction2(ctx, tjs_tcp_constructor, "TCP", 1, JS_CFUNC_constructor, 0);
     JS_SetPropertyFunctionList(ctx, obj, tjs_tcp_class_funcs, countof(tjs_tcp_class_funcs));
-    JS_SetModuleExport(ctx, m, "TCP", obj);
+    JS_DefinePropertyValueStr(ctx, ns, "TCP", obj, JS_PROP_C_W_E);
 
     /* TTY class */
     JS_NewClassID(&tjs_tty_class_id);
@@ -929,7 +929,7 @@ void tjs_mod_streams_init(JSContext *ctx, JSModuleDef *m) {
     /* TTY object */
     obj = JS_NewCFunction2(ctx, tjs_tty_constructor, "TTY", 1, JS_CFUNC_constructor, 0);
     JS_SetPropertyFunctionList(ctx, obj, tjs_tty_class_funcs, countof(tjs_tty_class_funcs));
-    JS_SetModuleExport(ctx, m, "TTY", obj);
+    JS_DefinePropertyValueStr(ctx, ns, "TTY", obj, JS_PROP_C_W_E);
 
     /* Pipe class */
     JS_NewClassID(&tjs_pipe_class_id);
@@ -940,11 +940,5 @@ void tjs_mod_streams_init(JSContext *ctx, JSModuleDef *m) {
 
     /* Pipe object */
     obj = JS_NewCFunction2(ctx, tjs_pipe_constructor, "Pipe", 1, JS_CFUNC_constructor, 0);
-    JS_SetModuleExport(ctx, m, "Pipe", obj);
-}
-
-void tjs_mod_streams_export(JSContext *ctx, JSModuleDef *m) {
-    JS_AddModuleExport(ctx, m, "TCP");
-    JS_AddModuleExport(ctx, m, "TTY");
-    JS_AddModuleExport(ctx, m, "Pipe");
+    JS_DefinePropertyValueStr(ctx, ns, "Pipe", obj, JS_PROP_C_W_E);
 }

--- a/src/timers.c
+++ b/src/timers.c
@@ -1,5 +1,5 @@
 /*
- * QuickJS libuv bindings
+ * txiki.js
  *
  * Copyright (c) 2019-present Saúl Ibarra Corretgé <s@saghul.net>
  *
@@ -163,17 +163,13 @@ static JSValue tjs_clearTimeout(JSContext *ctx, JSValueConst this_val, int argc,
 
 static const JSCFunctionListEntry tjs_timer_funcs[] = {
     JS_CFUNC_MAGIC_DEF("setTimeout", 2, tjs_setTimeout, 0),
-    JS_CFUNC_DEF("clearTimeout", 1, tjs_clearTimeout),
+    TJS_CFUNC_DEF("clearTimeout", 1, tjs_clearTimeout),
     JS_CFUNC_MAGIC_DEF("setInterval", 2, tjs_setTimeout, 1),
-    JS_CFUNC_DEF("clearInterval", 1, tjs_clearTimeout)
+    TJS_CFUNC_DEF("clearInterval", 1, tjs_clearTimeout)
 };
 
-void tjs_mod_timers_init(JSContext *ctx, JSModuleDef *m) {
+void tjs__mod_timers_init(JSContext *ctx, JSValue ns) {
     JS_NewClassID(&tjs_timer_class_id);
     JS_NewClass(JS_GetRuntime(ctx), tjs_timer_class_id, &tjs_timer_class);
-    JS_SetModuleExportList(ctx, m, tjs_timer_funcs, countof(tjs_timer_funcs));
-}
-
-void tjs_mod_timers_export(JSContext *ctx, JSModuleDef *m) {
-    JS_AddModuleExportList(ctx, m, tjs_timer_funcs, countof(tjs_timer_funcs));
+    JS_SetPropertyFunctionList(ctx, ns, tjs_timer_funcs, countof(tjs_timer_funcs));
 }

--- a/src/udp.c
+++ b/src/udp.c
@@ -376,14 +376,14 @@ static JSValue tjs_udp_bind(JSContext *ctx, JSValueConst this_val, int argc, JSV
 }
 
 static const JSCFunctionListEntry tjs_udp_proto_funcs[] = {
-    JS_CFUNC_DEF("close", 0, tjs_udp_close),
-    JS_CFUNC_DEF("recv", 1, tjs_udp_recv),
-    JS_CFUNC_DEF("send", 2, tjs_udp_send),
-    JS_CFUNC_DEF("fileno", 0, tjs_udp_fileno),
+    TJS_CFUNC_DEF("close", 0, tjs_udp_close),
+    TJS_CFUNC_DEF("recv", 1, tjs_udp_recv),
+    TJS_CFUNC_DEF("send", 2, tjs_udp_send),
+    TJS_CFUNC_DEF("fileno", 0, tjs_udp_fileno),
     JS_CFUNC_MAGIC_DEF("getsockname", 0, tjs_udp_getsockpeername, 0),
     JS_CFUNC_MAGIC_DEF("getpeername", 0, tjs_udp_getsockpeername, 1),
-    JS_CFUNC_DEF("connect", 1, tjs_udp_connect),
-    JS_CFUNC_DEF("bind", 2, tjs_udp_bind),
+    TJS_CFUNC_DEF("connect", 1, tjs_udp_connect),
+    TJS_CFUNC_DEF("bind", 2, tjs_udp_bind),
     JS_PROP_STRING_DEF("[Symbol.toStringTag]", "UDP", JS_PROP_CONFIGURABLE),
 };
 
@@ -393,7 +393,7 @@ static const JSCFunctionListEntry tjs_udp_class_funcs[] = {
     JS_PROP_INT32_DEF("REUSEADDR", UV_UDP_REUSEADDR, 0),
 };
 
-void tjs_mod_udp_init(JSContext *ctx, JSModuleDef *m) {
+void tjs__mod_udp_init(JSContext *ctx, JSValue ns) {
     JSValue proto, obj;
 
     /* UDP class */
@@ -406,9 +406,5 @@ void tjs_mod_udp_init(JSContext *ctx, JSModuleDef *m) {
     /* UDP object */
     obj = JS_NewCFunction2(ctx, tjs_udp_constructor, "UDP", 1, JS_CFUNC_constructor, 0);
     JS_SetPropertyFunctionList(ctx, obj, tjs_udp_class_funcs, countof(tjs_udp_class_funcs));
-    JS_SetModuleExport(ctx, m, "UDP", obj);
-}
-
-void tjs_mod_udp_export(JSContext *ctx, JSModuleDef *m) {
-    JS_AddModuleExport(ctx, m, "UDP");
+    JS_DefinePropertyValueStr(ctx, ns, "UDP", obj, JS_PROP_C_W_E);
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -76,7 +76,9 @@ struct AssertionInfo {
 
 void tjs_assert(const struct AssertionInfo info);
 
-#define TJS_CONST(x) JS_PROP_INT32_DEF(#x, x, JS_PROP_CONFIGURABLE)
+#define TJS_CONST(x) JS_PROP_INT32_DEF(#x, x, JS_PROP_ENUMERABLE)
+#define TJS_CONST2(name, val) JS_PROP_INT32_DEF(name, val, JS_PROP_ENUMERABLE)
+#define TJS_CFUNC_DEF(name, length, func1) { name, JS_PROP_C_W_E, JS_DEF_CFUNC, 0, .u = { .func = { length, JS_CFUNC_generic, { .generic = func1 } } } }
 
 uv_loop_t *tjs_get_loop(JSContext *ctx);
 int tjs_obj2addr(JSContext *ctx, JSValueConst obj, struct sockaddr_storage *ss);

--- a/src/wasm.c
+++ b/src/wasm.c
@@ -292,8 +292,8 @@ static JSValue tjs_wasm_moduleexports(JSContext *ctx, JSValueConst this_val, int
         const char *name = m3_GetFunctionName(f);
         if (name) {
             JSValue item = JS_NewObjectProto(ctx, JS_NULL);
-            JS_SetPropertyStr(ctx, item, "name", JS_NewString(ctx, name));
-            JS_SetPropertyStr(ctx, item, "kind", JS_NewString(ctx, "function"));
+            JS_DefinePropertyValueStr(ctx, item, "name", JS_NewString(ctx, name), JS_PROP_C_W_E);
+            JS_DefinePropertyValueStr(ctx, item, "kind", JS_NewString(ctx, "function"), JS_PROP_C_W_E);
             JS_DefinePropertyValueUint32(ctx, exports, j, item, JS_PROP_C_W_E);
             j++;
         }
@@ -345,17 +345,17 @@ static JSValue tjs_wasm_parsemodule(JSContext *ctx, JSValueConst this_val, int a
 }
 
 static const JSCFunctionListEntry tjs_wasm_funcs[] = {
-    JS_CFUNC_DEF("buildInstance", 1, tjs_wasm_buildinstance),
-    JS_CFUNC_DEF("moduleExports", 1, tjs_wasm_moduleexports),
-    JS_CFUNC_DEF("parseModule", 1, tjs_wasm_parsemodule),
+    TJS_CFUNC_DEF("buildInstance", 1, tjs_wasm_buildinstance),
+    TJS_CFUNC_DEF("moduleExports", 1, tjs_wasm_moduleexports),
+    TJS_CFUNC_DEF("parseModule", 1, tjs_wasm_parsemodule),
 };
 
 static const JSCFunctionListEntry tjs_wasm_instance_funcs[] = {
-    JS_CFUNC_DEF("callFunction", 1, tjs_wasm_callfunction),
-    JS_CFUNC_DEF("linkWasi", 0, tjs_wasm_linkwasi),
+    TJS_CFUNC_DEF("callFunction", 1, tjs_wasm_callfunction),
+    TJS_CFUNC_DEF("linkWasi", 0, tjs_wasm_linkwasi),
 };
 
-void tjs_mod_wasm_init(JSContext *ctx, JSModuleDef *m) {
+void tjs__mod_wasm_init(JSContext *ctx, JSValue ns) {
     /* Module object */
     JS_NewClassID(&tjs_wasm_module_class_id);
     JS_NewClass(JS_GetRuntime(ctx), tjs_wasm_module_class_id, &tjs_wasm_module_class);
@@ -371,9 +371,5 @@ void tjs_mod_wasm_init(JSContext *ctx, JSModuleDef *m) {
     JSValue obj = JS_NewObjectProto(ctx, JS_NULL);
     JS_SetPropertyFunctionList(ctx, obj, tjs_wasm_funcs, countof(tjs_wasm_funcs));
 
-    JS_SetModuleExport(ctx, m, "wasm", obj);
-}
-
-void tjs_mod_wasm_export(JSContext *ctx, JSModuleDef *m) {
-    JS_AddModuleExport(ctx, m, "wasm");
+    JS_DefinePropertyValueStr(ctx, ns, "wasm", obj, JS_PROP_C_W_E);
 }

--- a/src/xhr.c
+++ b/src/xhr.c
@@ -757,16 +757,16 @@ static const JSCFunctionListEntry tjs_xhr_proto_funcs[] = {
     JS_CGETSET_DEF("timeout", tjs_xhr_timeout_get, tjs_xhr_timeout_set),
     JS_CGETSET_DEF("upload", tjs_xhr_upload_get, NULL),
     JS_CGETSET_DEF("withCcredentials", tjs_xhr_withcredentials_get, tjs_xhr_withcredentials_set),
-    JS_CFUNC_DEF("abort", 0, tjs_xhr_abort),
-    JS_CFUNC_DEF("getAllResponseHeaders", 0, tjs_xhr_getallresponseheaders),
-    JS_CFUNC_DEF("getResponseHeader", 1, tjs_xhr_getresponseheader),
-    JS_CFUNC_DEF("open", 5, tjs_xhr_open),
-    JS_CFUNC_DEF("overrideMimeType", 1, tjs_xhr_overridemimetype),
-    JS_CFUNC_DEF("send", 1, tjs_xhr_send),
-    JS_CFUNC_DEF("setRequestHeader", 2, tjs_xhr_setrequestheader),
+    TJS_CFUNC_DEF("abort", 0, tjs_xhr_abort),
+    TJS_CFUNC_DEF("getAllResponseHeaders", 0, tjs_xhr_getallresponseheaders),
+    TJS_CFUNC_DEF("getResponseHeader", 1, tjs_xhr_getresponseheader),
+    TJS_CFUNC_DEF("open", 5, tjs_xhr_open),
+    TJS_CFUNC_DEF("overrideMimeType", 1, tjs_xhr_overridemimetype),
+    TJS_CFUNC_DEF("send", 1, tjs_xhr_send),
+    TJS_CFUNC_DEF("setRequestHeader", 2, tjs_xhr_setrequestheader),
 };
 
-void tjs_mod_xhr_init(JSContext *ctx, JSModuleDef *m) {
+void tjs__mod_xhr_init(JSContext *ctx,JSValue ns) {
     JSValue proto, obj;
 
     /* XHR class */
@@ -779,9 +779,5 @@ void tjs_mod_xhr_init(JSContext *ctx, JSModuleDef *m) {
     /* XHR object */
     obj = JS_NewCFunction2(ctx, tjs_xhr_constructor, "XMLHttpRequest", 1, JS_CFUNC_constructor, 0);
     JS_SetPropertyFunctionList(ctx, obj, tjs_xhr_class_funcs, countof(tjs_xhr_class_funcs));
-    JS_SetModuleExport(ctx, m, "XMLHttpRequest", obj);
-}
-
-void tjs_mod_xhr_export(JSContext *ctx, JSModuleDef *m) {
-    JS_AddModuleExport(ctx, m, "XMLHttpRequest");
+    JS_DefinePropertyValueStr(ctx, ns, "XMLHttpRequest", obj, JS_PROP_C_W_E);
 }


### PR DESCRIPTION
Use a simple global object where we attach all the stuff and then just
delete it.

This simplifies the process since it's not an internal module.