### PR TITLE
core: add import.meta.{dirname,basename}

### DIFF
--- a/tests/run.js
+++ b/tests/run.js
@@ -1,8 +1,5 @@
 import { path } from '@tjs/std';
 
-const { basename, dirname, join } = path;
-
-const thisFile = import.meta.url.slice(7);  // strip "file://"
 
 const TIMEOUT = 10 * 1000;
 
@@ -53,7 +50,7 @@ class Test {
         const status = status_.value;
 
         return {
-            name: basename(this._fileName),
+            name: path.basename(this._fileName),
             failed: status.exit_status !== 0 || status.term_signal !== 0,
             status,
             stdout: stdout.value,
@@ -96,13 +93,13 @@ function printResult(result) {
 }
 
 (async function() {
-    const dir = await tjs.fs.realpath(tjs.args[2] || dirname(thisFile));
+    const dir = await tjs.fs.realpath(tjs.args[2] || import.meta.dirname);
     const dirIter = await tjs.fs.readdir(dir);
     const tests = [];
     for await (const item of dirIter) {
         const { name } = item;
         if (name.startsWith('test-') && name.endsWith('.js')) {
-            tests.push(new Test(join(dir, name)));
+            tests.push(new Test(path.join(dir, name)));
         }
     }
 

--- a/tests/test-abort-on-unhandled-rejection.js
+++ b/tests/test-abort-on-unhandled-rejection.js
@@ -1,15 +1,11 @@
 import assert from './assert.js';
 import { path } from '@tjs/std';
 
-const { dirname, join } = path;
-
-const thisFile = import.meta.url.slice(7);   // strip "file://"
-
 
 (async () => {
     const args = [
         tjs.exepath(),
-        join(dirname(thisFile), 'helpers', 'unhandled-rejection.js')
+        path.join(import.meta.dirname, 'helpers', 'unhandled-rejection.js')
     ];
     const proc = tjs.spawn(args, { stdout: 'ignore', stderr: 'pipe' });
     const buf = new Uint8Array(4096);

--- a/tests/test-wasm-f32.js
+++ b/tests/test-wasm-f32.js
@@ -1,13 +1,9 @@
 import assert from './assert.js';
 import { path } from '@tjs/std';
 
-const { dirname, join } = path;
-
-const thisFile = import.meta.url.slice(7);   // strip "file://"
-
 
 (async () => {
-    const data = await tjs.fs.readFile(join(dirname(thisFile), 'wasm', 'f32.wasm'));
+    const data = await tjs.fs.readFile(path.join(import.meta.dirname, 'wasm', 'f32.wasm'));
     const { instance } = await WebAssembly.instantiate(data);
     const { exports } = instance;
 

--- a/tests/test-wasm-f64.js
+++ b/tests/test-wasm-f64.js
@@ -1,13 +1,9 @@
 import assert from './assert.js';
 import { path } from '@tjs/std';
 
-const { dirname, join } = path;
-
-const thisFile = import.meta.url.slice(7);   // strip "file://"
-
 
 (async () => {
-    const data = await tjs.fs.readFile(join(dirname(thisFile), 'wasm', 'f64.wasm'));
+    const data = await tjs.fs.readFile(path.join(import.meta.dirname, 'wasm', 'f64.wasm'));
     const { instance } = await WebAssembly.instantiate(data);
     const { exports } = instance;
 

--- a/tests/test-wasm-i32.js
+++ b/tests/test-wasm-i32.js
@@ -1,13 +1,9 @@
 import assert from './assert.js';
 import { path } from '@tjs/std';
 
-const { dirname, join } = path;
-
-const thisFile = import.meta.url.slice(7);   // strip "file://"
-
 
 (async () => {
-    const data = await tjs.fs.readFile(join(dirname(thisFile), 'wasm', 'i32.wasm'));
+    const data = await tjs.fs.readFile(path.join(import.meta.dirname, 'wasm', 'i32.wasm'));
     const { instance } = await WebAssembly.instantiate(data);
     const { exports } = instance;
 

--- a/tests/test-wasm-i64.js
+++ b/tests/test-wasm-i64.js
@@ -1,13 +1,9 @@
 import assert from './assert.js';
 import { path } from '@tjs/std';
 
-const { dirname, join } = path;
-
-const thisFile = import.meta.url.slice(7);   // strip "file://"
-
 
 (async () => {
-    const data = await tjs.fs.readFile(join(dirname(thisFile), 'wasm', 'i64.wasm'));
+    const data = await tjs.fs.readFile(path.join(import.meta.dirname, 'wasm', 'i64.wasm'));
     const { instance } = await WebAssembly.instantiate(data);
     const { exports } = instance;
 

--- a/tests/test-wasm-multi.js
+++ b/tests/test-wasm-multi.js
@@ -1,13 +1,9 @@
 import assert from './assert.js';
 import { path } from '@tjs/std';
 
-const { dirname, join } = path;
-
-const thisFile = import.meta.url.slice(7);   // strip "file://"
-
 
 (async () => {
-    const data = await tjs.fs.readFile(join(dirname(thisFile), 'wasm', 'multi.wasm'));
+    const data = await tjs.fs.readFile(path.join(import.meta.dirname, 'wasm', 'multi.wasm'));
     const { instance } = await WebAssembly.instantiate(data);
     const { exports } = instance;
 

--- a/tests/test-wasm-wasi.js
+++ b/tests/test-wasm-wasi.js
@@ -1,15 +1,11 @@
 import assert from './assert.js';
 import { path } from '@tjs/std';
 
-const { dirname, join } = path;
-
-const thisFile = import.meta.url.slice(7);   // strip "file://"
-
 
 (async () => {
     const args = [
         tjs.exepath(),
-        join(dirname(thisFile), 'wasi', 'launcher.js'),
+        path.join(import.meta.dirname, 'wasi', 'launcher.js'),
         'test.wasm'
     ];
     const proc = tjs.spawn(args, { stdout: 'pipe' });

--- a/tests/test-worker-et.js
+++ b/tests/test-worker-et.js
@@ -1,12 +1,8 @@
 import assert from './assert.js';
 import { path } from '@tjs/std';
 
-const { dirname, join } = path;
 
-const thisFile = import.meta.url.slice(7);   // strip "file://"
-
-
-const w = new Worker(join(dirname(thisFile), 'helpers', 'worker.js'));
+const w = new Worker(path.join(import.meta.dirname, 'helpers', 'worker.js'));
 const timer = setTimeout(() => {
     w.terminate();
 }, 1000);

--- a/tests/test-worker.js
+++ b/tests/test-worker.js
@@ -1,13 +1,9 @@
 import assert from './assert.js';
 import { path } from '@tjs/std';
 
-const { dirname, join } = path;
-
-const thisFile = import.meta.url.slice(7);   // strip "file://"
-
 
 const data = JSON.stringify({foo: 42, bar: 'baz!'});
-const w = new Worker(join(dirname(thisFile), 'helpers', 'worker.js'));
+const w = new Worker(path.join(import.meta.dirname, 'helpers', 'worker.js'));
 const timer = setTimeout(() => {
     w.terminate();
 }, 1000);

--- a/tests/wasi/launcher.js
+++ b/tests/wasi/launcher.js
@@ -1,13 +1,10 @@
 import { path } from '@tjs/std';
 
-const { dirname, join } = path;
-
-const thisFile = import.meta.url.slice(7);   // strip "file://"
 
 (async () => {
     const script = tjs.args[2];
     const args = tjs.args.slice(3);
-    const bytes = await tjs.fs.readFile(join(dirname(thisFile),script));
+    const bytes = await tjs.fs.readFile(path.join(import.meta.dirname,script));
     const module = new WebAssembly.Module(bytes);
     const wasi = new WebAssembly.WASI({ args });
     const importObject = { wasi_unstable: wasi.wasiImport };


### PR DESCRIPTION
Some helpful extras that can be used on each file instead of having to
parse import.meta.url.

Only defined on actual files.