### PR TITLE
sockets: don't make the read / write functions async

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
   build-alpine:
     name: Alpine Linux
     runs-on: ubuntu-latest
-    container: alpine:3.10
+    container: alpine:latest
     strategy:
       fail-fast: false
       matrix:

--- a/examples/echo-client.js
+++ b/examples/echo-client.js
@@ -16,8 +16,7 @@ import { addr } from './utils.js';
             port: 1234
         }
     });
-    
-    console.log(options);
+
     const conn = await tjs.connect('tcp', {ip: options.connect, port: options.port});
     
     console.log(`Connected to ${addr(conn.remoteAddress)}`);

--- a/src/js/bundle.js
+++ b/src/js/bundle.js
@@ -13493,10 +13493,10 @@ var Connection = class {
   constructor(handle) {
     this[kHandle] = handle;
   }
-  async read(buf) {
+  read(buf) {
     return this[kHandle].read(buf);
   }
-  async write(buf) {
+  write(buf) {
     return this[kHandle].write(buf);
   }
   get localAddress() {
@@ -13544,10 +13544,10 @@ var DatagramEndpoint = class {
   constructor(handle) {
     this[kHandle] = handle;
   }
-  async recv(buf) {
+  recv(buf) {
     return this[kHandle].recv(buf);
   }
-  async send(buf, taddr) {
+  send(buf, taddr) {
     return this[kHandle].send(buf, taddr);
   }
   get localAddress() {

--- a/src/js/tjs/sockets.js
+++ b/src/js/tjs/sockets.js
@@ -85,11 +85,11 @@ class Connection {
         this[kHandle] = handle;
     }
 
-    async read(buf) {
+    read(buf) {
         return this[kHandle].read(buf);
     }
 
-    async write(buf) {
+    write(buf) {
         return this[kHandle].write(buf);
     }
 
@@ -155,11 +155,11 @@ class DatagramEndpoint {
         this[kHandle] = handle;
     }
 
-    async recv(buf) {
+    recv(buf) {
         return this[kHandle].recv(buf);
     }
 
-    async send(buf, taddr) {
+    send(buf, taddr) {
         return this[kHandle].send(buf, taddr);
     }
 

--- a/tests/test-pipe.js
+++ b/tests/test-pipe.js
@@ -34,6 +34,8 @@ async function doEchoServer(server) {
     nread = await client.read(buf);
     dataStr = decoder.decode(buf.subarray(0, nread));
     assert.eq(dataStr, "PING", "sending works");
+    assert.throws(() => { client.write('PING'); }, TypeError, "sending anything else gives TypeError");
+    assert.throws(() => { client.write(1234); }, TypeError, "sending anything else gives TypeError");
     client.close();
     server.close();
 

--- a/tests/test-tcp.js
+++ b/tests/test-tcp.js
@@ -22,7 +22,7 @@ async function doEchoServer(server) {
 }
 
 (async () => {
-    const server = await tjs.listen('tcp', '127.0.0.1');
+    const server = await tjs.listen('tcp', '0.0.0.0');
 
     doEchoServer(server);
 

--- a/tests/test-tcp.js
+++ b/tests/test-tcp.js
@@ -35,6 +35,8 @@ async function doEchoServer(server) {
     nread = await client.read(readBuf);
     dataStr = decoer.decode(readBuf.subarray(0, nread));
     assert.eq(dataStr, "PING", "sending works");
+    assert.throws(() => { client.write("PING"); }, TypeError, "sending anything else gives TypeError");
+    assert.throws(() => { client.write(1234); }, TypeError, "sending anything else gives TypeError");
     client.close();
     server.close();
 

--- a/tests/test-udp.js
+++ b/tests/test-udp.js
@@ -32,6 +32,8 @@ async function doEchoServer(server) {
     dataStr = decoder.decode(rcvBuf.subarray(0, rinfo.nread));
     assert.eq(dataStr, 'PING', 'sending works');
     assert.eq(serverAddr, rinfo.addr, "source address matches");
+    assert.throws(() => { client.send('PING', serverAddr); }, TypeError, "sending anything else gives TypeError");
+    assert.throws(() => { client.send(1234, serverAddr); }, TypeError, "sending anything else gives TypeError");
     client.close();
     server.close();
 })();


### PR DESCRIPTION
They underlying functions already are, as in, they return a Promise. By
not making the wrapper function async we allow for exceptions that the
wrapped function may raise to buddle up instead of resulting in a
rejected promise.