### PR TITLE
core,repl: use indirect eval in the repl

### DIFF
--- a/src/js/bundle.js
+++ b/src/js/bundle.js
@@ -13644,7 +13644,6 @@ var noExport = [
   "XMLHttpRequest",
   "clearInterval",
   "clearTimeout",
-  "evalScript",
   "guessHandle",
   "hrtimeMs",
   "random",
@@ -13660,12 +13659,6 @@ for (const [key, value] of Object.entries(core6)) {
 }
 tjs2.args = Object.freeze(core6.args);
 tjs2.versions = Object.freeze(core6.versions);
-Object.defineProperty(tjs2, "__evalScript", {
-  enumerable: false,
-  configurable: false,
-  writable: false,
-  value: core6.evalScript
-});
 Object.defineProperty(tjs2, "connect", {
   enumerable: true,
   configurable: false,

--- a/src/js/repl.js
+++ b/src/js/repl.js
@@ -34,6 +34,9 @@ window.addEventListener('unhandledrejection', event => {
     /* expose stdlib */
     g.std = std;
 
+    /* for indirect eval */
+    var gEval = g.eval;
+
     /* close global objects */
     var Object = g.Object;
     var String = g.String;
@@ -996,8 +999,7 @@ window.addEventListener('unhandledrejection', event => {
         
         try {
             var now = (new Date).getTime();
-            /* eval as a script */
-            result = tjs.__evalScript(expr);
+            result = gEval(expr);
             eval_time = (new Date).getTime() - now;
             stdout_write(colors[styles.result]);
             print(result);

--- a/src/js/tjs/index.js
+++ b/src/js/tjs/index.js
@@ -16,7 +16,6 @@ const noExport = [
     'XMLHttpRequest',
     'clearInterval',
     'clearTimeout',
-    'evalScript',
     'guessHandle',
     'hrtimeMs',
     'random',
@@ -36,14 +35,6 @@ for (const [key, value] of Object.entries(core)) {
 // These values should be immutable.
 tjs.args = Object.freeze(core.args);
 tjs.versions = Object.freeze(core.versions);
-
-// For the REPL.
-Object.defineProperty(tjs, '__evalScript', {
-    enumerable: false,
-    configurable: false,
-    writable: false,
-    value: core.evalScript
-});
 
 // Sockets.
 Object.defineProperty(tjs, 'connect', {

--- a/src/sys.c
+++ b/src/sys.c
@@ -34,18 +34,6 @@ static JSValue js_std_gc(JSContext *ctx, JSValueConst this_val, int argc, JSValu
     return JS_UNDEFINED;
 }
 
-static JSValue js_evalScript(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
-    const char *str;
-    size_t len;
-    JSValue ret;
-    str = JS_ToCStringLen(ctx, &len, argv[0]);
-    if (!str)
-        return JS_EXCEPTION;
-    ret = JS_Eval(ctx, str, len, "<evalScript>", JS_EVAL_TYPE_GLOBAL | JS_EVAL_FLAG_BACKTRACE_BARRIER);
-    JS_FreeCString(ctx, str);
-    return ret;
-}
-
 static JSValue tjs_exepath(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
     char buf[1024];
     size_t size = sizeof(buf);
@@ -76,7 +64,6 @@ static JSValue tjs_exepath(JSContext *ctx, JSValueConst this_val, int argc, JSVa
 
 static const JSCFunctionListEntry tjs_sys_funcs[] = {
     TJS_CFUNC_DEF("gc", 0, js_std_gc),
-    TJS_CFUNC_DEF("evalScript", 1, js_evalScript),
 };
 
 void tjs__mod_sys_init(JSContext *ctx, JSValue ns) {


### PR DESCRIPTION
This removes a helper function which is now unneeded. It only allowed us
to have a barrier in the backtrace, but it's actually nice to see the
full backtrace while working on the repl.