### PR TITLE
core: rename TJS_EvalFile to TJS_EvalModule

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -74,7 +74,7 @@ static int eval_expr(JSContext *ctx, const char *buf) {
 
 static int eval_module(JSContext *ctx, const char *filepath) {
     int ret = 0;
-    JSValue val = TJS_EvalFile(ctx, filepath, JS_EVAL_TYPE_MODULE, true);
+    JSValue val = TJS_EvalModule(ctx, filepath, true);
 
     if (JS_IsException(val)) {
         tjs_dump_error(ctx);

--- a/src/tjs.h
+++ b/src/tjs.h
@@ -47,7 +47,7 @@ JSContext *TJS_GetJSContext(TJSRuntime *qrt);
 TJSRuntime *TJS_GetRuntime(JSContext *ctx);
 int TJS_Run(TJSRuntime *qrt);
 void TJS_Stop(TJSRuntime *qrt);
-JSValue TJS_EvalFile(JSContext *ctx, const char *filename, int eval_flags, bool is_main);
+JSValue TJS_EvalModule(JSContext *ctx, const char *filename, bool is_main);
 int TJS_RunRepl(JSContext *ctx);
 
 #endif

--- a/src/worker.c
+++ b/src/worker.c
@@ -85,7 +85,7 @@ static JSValue worker_eval(JSContext *ctx, int argc, JSValueConst *argv) {
         goto error;
     }
 
-    ret = TJS_EvalFile(ctx, filename, JS_EVAL_TYPE_MODULE, false);
+    ret = TJS_EvalModule(ctx, filename, false);
     JS_FreeCString(ctx, filename);
 
     if (JS_IsException(ret)) {


### PR DESCRIPTION
That's how we use it everywhere, make it explicit about it being for
modules only.