### PR TITLE
fs: add mkdir()

### DIFF
--- a/docs/txikijs.d.ts
+++ b/docs/txikijs.d.ts
@@ -434,6 +434,14 @@ declare namespace tjs {
     function rmdir(path: string): Promise<void>;
 
     /**
+     * Create a directory at the given path.
+     *
+     * @param path The path to of the directory to be created.
+     * @param mode The file mode for the new directory.
+     */
+    function mkdir(path: string, mode?: number): Promise<void>;
+
+    /**
      * Copies the source file into the target.
      *
      * If `COPYFILE_EXCL` is specified the operation will fail if the target exists.

--- a/tests/test-fs.js
+++ b/tests/test-fs.js
@@ -34,8 +34,21 @@ async function mkstemp() {
     await tjs.unlink(path);
 };
 
+async function mkdir() {
+    const path = `./test_mkdir${tjs.pid}`;
+    const s_irwxu = 0o700;
+    const s_ifmt = ~0o777;
+    await tjs.mkdir(path, s_irwxu);
+    const result = await tjs.stat(path);
+    assert.ok(result.isDirectory, 'directory was created ok');
+    /* NOTE: File permission mode not supported on Windows. */
+    if (tjs.platform !== 'windows')
+      assert.eq(result.mode & ~s_ifmt, s_irwxu);
+    await tjs.rmdir(path);
+};
 
 (async () => {
     await readWrite();
     await mkstemp();
+    await mkdir();
 })();


### PR DESCRIPTION
Hi,

I've come across the need for mkdir so I implemented it and it is presented here in this PR.

But I was hoping to improve on the usability of the `mode` parameter, considering octal literals are deprecated, but I'm not sure what would fit best.

In the TypeScript definition I see the `S_XXX` variable, but I can't find any of the flags mentioned added anywhere. If I've just missed them somehow, please let me know.

First thought was to declare them in fs.c e.g.
```
--- a/src/fs.c
+++ b/src/fs.c
@@ -1151,6 +1151,29 @@ static const JSCFunctionListEntry tjs_fs_funcs[] = {
     TJS_CONST2("COPYFILE_EXCL", UV_FS_COPYFILE_EXCL),
     TJS_CONST2("COPYFILE_FICLONE", UV_FS_COPYFILE_FICLONE),
     TJS_CONST2("COPYFILE_FICLONE_FORCE", UV_FS_COPYFILE_FICLONE_FORCE),
+    TJS_CONST(S_IFMT),
+    TJS_CONST(S_IFSOCK),
+    TJS_CONST(S_IFLNK),
+    TJS_CONST(S_IFREG),
...
+    TJS_CONST(S_IRWXO),
+    TJS_CONST(S_IROTH),
+    TJS_CONST(S_IWOTH),
+    TJS_CONST(S_IXOTH),
     TJS_CFUNC_DEF("open", 3, tjs_fs_open),
     TJS_CFUNC_DEF("newStdioFile", 2, tjs_fs_new_stdio_file),
     TJS_CFUNC_MAGIC_DEF("stat", 1, tjs_fs_stat, 0),

```
But that pollutes the tjs namespace a lot. There are over 20 of them.

To group them together I considered adding them as an enum to the .d.ts but that doesn't help people who don't use TypeScript.
Or maybe they could be added to an object under tjs in fs.c like `tjs.FileMode`, and declared as constants in .d.ts.

Any thoughts on what would be preferred here, if any?

Thanks,

Sam

-------------

Added tjs.mkdir() and simple test.
Mode mask parameter defaults to 0777, which is the default from the
coreutils mkdir program.

Ref: https://github.com/saghul/txiki.js/issues/247