### PR TITLE
TypeScript definition file fixes and extras

### DIFF
--- a/docs/txikijs.d.ts
+++ b/docs/txikijs.d.ts
@@ -69,7 +69,7 @@ declare namespace tjs {
         /**
          * The signal that this signal handler was registered for.
          */
-        signum: number;
+        signal: Signal;
 
         /**
          * Stop the signal handler. The registered signal handler function

--- a/docs/txikijs.d.ts
+++ b/docs/txikijs.d.ts
@@ -234,32 +234,115 @@ declare namespace tjs {
 
     /**
      * Error type. It mostly encapsulates the libuv and other platform library errors.
+     * The available error number properties depends on the platform.
      */
-    interface ErrorType {
-        /**
-         * Error code constants.
-         */
-        EXXX: number;
+    class Error {
+
+        constructor(errno: number);
 
         /**
-         * Returns the string representing the given error code.
-         *
-         * @param code Error code.
-         */
-        strerror(code: number): string;
-
-        /**
-         * On a specific instance, the represented error code.
+         * The represented error number.
          */
         errno: number;
 
         /**
-         * On a specific instance, the error string representation.
+         * The error string representation.
          */
         message: string;
-    }
 
-    const Error: ErrorType;
+        /*
+         * Error code constants.
+         */
+        static E2BIG: number;
+        static EACCES: number;
+        static EADDRINUSE: number;
+        static EADDRNOTAVAIL: number;
+        static EAFNOSUPPORT: number;
+        static EAGAIN: number;
+        static EAI_ADDRFAMILY: number;
+        static EAI_AGAIN: number;
+        static EAI_BADFLAGS: number;
+        static EAI_BADHINTS: number;
+        static EAI_CANCELED: number;
+        static EAI_FAIL: number;
+        static EAI_FAMILY: number;
+        static EAI_MEMORY: number;
+        static EAI_NODATA: number;
+        static EAI_NONAME: number;
+        static EAI_OVERFLOW: number;
+        static EAI_PROTOCOL: number;
+        static EAI_SERVICE: number;
+        static EAI_SOCKTYPE: number;
+        static EALREADY: number;
+        static EBADF: number;
+        static EBUSY: number;
+        static ECANCELED: number;
+        static ECHARSET: number;
+        static ECONNABORTED: number;
+        static ECONNREFUSED: number;
+        static ECONNRESET: number;
+        static EDESTADDRREQ: number;
+        static EEXIST: number;
+        static EFAULT: number;
+        static EFBIG: number;
+        static EHOSTUNREACH: number;
+        static EINTR: number;
+        static EINVAL: number;
+        static EIO: number;
+        static EISCONN: number;
+        static EISDIR: number;
+        static ELOOP: number;
+        static EMFILE: number;
+        static EMSGSIZE: number;
+        static ENAMETOOLONG: number;
+        static ENETDOWN: number;
+        static ENETUNREACH: number;
+        static ENFILE: number;
+        static ENOBUFS: number;
+        static ENODEV: number;
+        static ENOENT: number;
+        static ENOMEM: number;
+        static ENONET: number;
+        static ENOPROTOOPT: number;
+        static ENOSPC: number;
+        static ENOSYS: number;
+        static ENOTCONN: number;
+        static ENOTDIR: number;
+        static ENOTEMPTY: number;
+        static ENOTSOCK: number;
+        static ENOTSUP: number;
+        static EOVERFLOW: number;
+        static EPERM: number;
+        static EPIPE: number;
+        static EPROTO: number;
+        static EPROTONOSUPPORT: number;
+        static EPROTOTYPE: number;
+        static ERANGE: number;
+        static EROFS: number;
+        static ESHUTDOWN: number;
+        static ESPIPE: number;
+        static ESRCH: number;
+        static ETIMEDOUT: number;
+        static ETXTBSY: number;
+        static EXDEV: number;
+        static UNKNOWN: number;
+        static EOF: number;
+        static ENXIO: number;
+        static EMLINK: number;
+        static EHOSTDOWN: number;
+        static EREMOTEIO: number;
+        static ENOTTY: number;
+        static EFTYPE: number;
+        static EILSEQ: number;
+        static ESOCKTNOSUPPORT: number;
+
+        /**
+         * Returns the string representing the given error number.
+         *
+         * @param code Error number.
+         */
+        static strerror(errno: number): string;
+    }
 
     /**
      * Returns the canonicalized absolute pathname.

--- a/docs/txikijs.d.ts
+++ b/docs/txikijs.d.ts
@@ -251,7 +251,7 @@ declare namespace tjs {
         /**
          * On a specific instance, the represented error code.
          */
-        code: number;
+        errno: number;
 
         /**
          * On a specific instance, the error string representation.

--- a/docs/txikijs.d.ts
+++ b/docs/txikijs.d.ts
@@ -56,7 +56,20 @@ declare namespace tjs {
     /**
      * Signal handler function.
      */
-    type SignalHandler = () => void;
+    type SignalHandlerFunction = () => void;
+
+    interface SignalHandler {
+        /**
+         * The signal that this signal handler was registered for.
+         */
+        signum: number;
+
+        /**
+         * Stop the signal handler. The registered signal handler function
+         * will no longer be called.
+         */
+        close(): void;
+    }
 
     /**
      * Registers a handler for the given signal.
@@ -68,7 +81,7 @@ declare namespace tjs {
      * @param sig Which signal to register a handler for.
      * @param handler Handler function.
      */
-    function signal(sig: string, handler: SignalHandler): void;
+    function signal(sig: string, handler: SignalHandlerFunction): SignalHandler;
 
     /**
      * Send a signal to a process.

--- a/docs/txikijs.d.ts
+++ b/docs/txikijs.d.ts
@@ -53,6 +53,13 @@ declare namespace tjs {
      */
     const args: string[];
 
+    type Signal = 'SIGHUP' | 'SIGINT' | 'SIGQUIT' | 'SIGILL' | 'SIGTRAP'
+      | 'SIGABRT' | 'SIGBUS' | 'SIGFPE' | 'SIGKILL' | 'SIGUSR1' | 'SIGSEGV'
+      | 'SIGUSR2' | 'SIGPIPE' | 'SIGALRM' | 'SIGTERM' | 'SIGSTKFLT'
+      | 'SIGCHLD' | 'SIGCONT' | 'SIGSTOP' | 'SIGTSTP' | 'SIGTTIN' | 'SIGTTOU'
+      | 'SIGURG' | 'SIGXCPU' | 'SIGXFSZ' | 'SIGVTALRM' | 'SIGPROF' | 'SIGWINCH'
+      | 'SIGPOLL' | 'SIGPWR' | 'SIGSYS';
+
     /**
      * Signal handler function.
      */
@@ -81,7 +88,7 @@ declare namespace tjs {
      * @param sig Which signal to register a handler for.
      * @param handler Handler function.
      */
-    function signal(sig: string, handler: SignalHandlerFunction): SignalHandler;
+    function signal(sig: Signal, handler: SignalHandlerFunction): SignalHandler;
 
     /**
      * Send a signal to a process.
@@ -89,7 +96,7 @@ declare namespace tjs {
      * @param pid The pid of the process to send a signal to.
      * @param sig The name of the signal to send. Defaults to "SIGTERM".
      */
-    function kill(pid: number, sig?: string): void;
+    function kill(pid: number, sig?: Signal): void;
 
     /**
      * Triggers a garbage collection cycle.
@@ -753,11 +760,11 @@ declare namespace tjs {
 
     interface ProcessStatus {
         exit_status: number;
-        term_signal: string;
+        term_signal: Signal|null;
     }
 
     interface Process {
-        kill(signal?: string): void;
+        kill(signal?: Signal): void;
         wait(): Promise<ProcessStatus>;
         pid: number;
         stdin?: Writer;

--- a/src/signals.c
+++ b/src/signals.c
@@ -138,16 +138,16 @@ static JSValue tjs_signal_handler_close(JSContext *ctx, JSValueConst this_val, i
     return JS_UNDEFINED;
 }
 
-static JSValue tjs_signal_handler_signum_get(JSContext *ctx, JSValueConst this_val) {
+static JSValue tjs_signal_handler_signal_get(JSContext *ctx, JSValueConst this_val) {
     TJSSignalHandler *sh = tjs_signal_handler_get(ctx, this_val);
     if (!sh)
         return JS_EXCEPTION;
-    return JS_NewInt32(ctx, sh->sig_num);
+    return sh->sig_num == 0 ? JS_NULL : JS_NewString(ctx, tjs_getsig(sh->sig_num));
 }
 
 static const JSCFunctionListEntry tjs_signal_handler_proto_funcs[] = {
     TJS_CFUNC_DEF("close", 0, tjs_signal_handler_close),
-    JS_CGETSET_DEF("signum", tjs_signal_handler_signum_get, NULL),
+    JS_CGETSET_DEF("signal", tjs_signal_handler_signal_get, NULL),
     JS_PROP_STRING_DEF("[Symbol.toStringTag]", "Signal Handler", JS_PROP_CONFIGURABLE),
 };
 

--- a/tests/test-signal.js
+++ b/tests/test-signal.js
@@ -1,0 +1,24 @@
+import assert from './assert.js';
+
+
+function sleep(seconds) {
+    return new Promise(resolve => setTimeout(resolve, seconds*1000));
+}
+
+(async () => {
+    const h = tjs.signal('SIGINT', () => {
+        tjs.exit(0);
+    });
+    assert.eq(h.signal, 'SIGINT');
+
+    if (tjs.platform === 'windows') {
+        /* Signals emulated on Windows do not allow signal() to be tested
+         * by sending a signal via kill(), so don't continue the test.
+         */
+        tjs.exit(0);
+    }
+
+    tjs.kill(tjs.pid, 'SIGINT');
+    await sleep(1);
+    assert.fail('Timed out waiting for signal');
+})()


### PR DESCRIPTION
I've been using TypeScript for a few scripts and have noticed a some parts txikijs.d.ts are out of sync with what tjs provides.

Instances of `tjs.Error` have the `errno` property and not the `code` property.
I've described `tjs.Error` as a class with static properties, but was this deliberately avoided?
I've listed the error numbers explicitly, because `EXXX` is not useful in TypeScript.
Considering the recent push to change signal names to strings, would it also be desirable to only expose the error name strings and not the error numbers?

For signals, I've added a `Signal` type to help with type checking when using the signal names.
I've also annotated the `tjs.signal()` return type and added a test for it because I couldn't work out how to use it until I realised that you need to prevent the returned handler from being garbage collected.

Is the definition file's main purpose to generate the docs currently? I think the best way to keep it in sync with the implementation would be to have the tests written in TypeScript.
If I converted the tests to TypeScript, would you be interested in the changes?

Let me know what you think.