### PR TITLE
xhr: fix ProgressEvent parameters not being passed to onprogress

### DIFF
--- a/src/js/bundle.js
+++ b/src/js/bundle.js
@@ -11585,6 +11585,26 @@ var PromiseRejectionEvent = class extends Event2 {
     return this[kPromiseRejectionReason];
   }
 };
+var kProgressEventLengthComputable = Symbol("kProgressEventLengthComputable");
+var kProgressEventLoaded = Symbol("kProgressEventLoaded");
+var kProgressEventTotal = Symbol("kProgressEventTotal");
+var ProgressEvent2 = class extends Event2 {
+  constructor(eventTye, init) {
+    super(eventTye, init);
+    this[kProgressEventLengthComputable] = init?.lengthComputable || false;
+    this[kProgressEventLoaded] = init?.loaded || 0;
+    this[kProgressEventTotal] = init?.total || 0;
+  }
+  get lengthComputable() {
+    return this[kProgressEventLengthComputable];
+  }
+  get loaded() {
+    return this[kProgressEventLoaded];
+  }
+  get total() {
+    return this[kProgressEventTotal];
+  }
+};
 Object.defineProperties(window, {
   EventTarget: {
     enumerable: true,
@@ -11615,6 +11635,12 @@ Object.defineProperties(window, {
     configurable: true,
     writable: true,
     value: PromiseRejectionEvent
+  },
+  ProgressEvent: {
+    enumerable: true,
+    configurable: true,
+    writable: true,
+    value: ProgressEvent2
   },
   CustomEvent: {
     enumerable: true,
@@ -12320,7 +12346,7 @@ var XMLHttpRequest2 = class extends EventTarget {
       this.dispatchEvent(new Event("loadstart"));
     };
     xhr.onprogress = (p2) => {
-      this.dispatchEvent(new Event("progress", p2));
+      this.dispatchEvent(new ProgressEvent("progress", p2));
     };
     xhr.onreadystatechange = () => {
       this.dispatchEvent(new Event("readystatechange"));

--- a/src/js/polyfills/event-target-polyfill.js
+++ b/src/js/polyfills/event-target-polyfill.js
@@ -64,6 +64,32 @@ class PromiseRejectionEvent extends Event {
     }
 }
 
+const kProgressEventLengthComputable = Symbol('kProgressEventLengthComputable');
+const kProgressEventLoaded = Symbol('kProgressEventLoaded');
+const kProgressEventTotal = Symbol('kProgressEventTotal');
+
+class ProgressEvent extends Event {
+    constructor(eventTye, init) {
+        super(eventTye, init);
+
+        this[kProgressEventLengthComputable] = init?.lengthComputable || false;
+        this[kProgressEventLoaded] = init?.loaded || 0;
+        this[kProgressEventTotal] = init?.total || 0;
+    }
+
+    get lengthComputable() {
+        return this[kProgressEventLengthComputable];
+    }
+
+    get loaded() {
+        return this[kProgressEventLoaded];
+    }
+
+    get total() {
+        return this[kProgressEventTotal];
+    }
+}
+
 Object.defineProperties(window, {
     EventTarget: {
         enumerable: true,
@@ -94,6 +120,12 @@ Object.defineProperties(window, {
         configurable: true,
         writable: true,
         value: PromiseRejectionEvent
+    },
+    ProgressEvent: {
+        enumerable: true,
+        configurable: true,
+        writable: true,
+        value: ProgressEvent
     },
     CustomEvent: {
         enumerable: true,

--- a/src/js/polyfills/xhr.js
+++ b/src/js/polyfills/xhr.js
@@ -36,7 +36,7 @@ class XMLHttpRequest extends EventTarget {
             this.dispatchEvent(new Event('loadstart'));
         };
         xhr.onprogress = p => {
-            this.dispatchEvent(new Event('progress', p));
+            this.dispatchEvent(new ProgressEvent('progress', p));
         };
         xhr.onreadystatechange = () => {
             this.dispatchEvent(new Event('readystatechange'));

--- a/tests/test-xhr-progress.js
+++ b/tests/test-xhr-progress.js
@@ -1,0 +1,20 @@
+import assert from './assert.js';
+
+
+let lengthComputable = false,  loaded, total;
+const url = 'https://httpbin.org/get';
+const xhrSync = new XMLHttpRequest();
+xhrSync.open('GET', url, false);
+xhrSync.onprogress = (evt) => {
+    lengthComputable = evt.lengthComputable;
+    loaded = evt.loaded;
+    total = evt.total;
+};
+xhrSync.send();
+
+assert.eq(xhrSync.status, 200, 'status is 200');
+assert.eq(lengthComputable, true, 'progress length is computable');
+assert.eq(typeof loaded, 'number', 'final progress loaded size is a number');
+assert.eq(typeof total, 'number', 'final progress total size is a number');
+assert.ok(total >= 0, 'final progress total size is greater than 0');
+assert.eq(loaded, total, 'final progress loaded size equals total size');


### PR DESCRIPTION
Hi @saghul,
This fixes XMLHttpRequest's onprogress not receiving the progress-related values in its event due to using the Event class directly.
It was the only occurrence I found of the Event constructor being used like this.