### PR TITLE
fs: default tjs.open() mode parameter to 0666

### DIFF
--- a/docs/txikijs.d.ts
+++ b/docs/txikijs.d.ts
@@ -551,7 +551,7 @@ declare namespace tjs {
     function lchown(path: string, owner: number, group: number): Promise<void>;
 
     /**
-     * Opens the file at the given path. Opening modes:
+     * Opens the file at the given path. Opening flags:
      *
      *   - r: open for reading
      *   - w: open for writing, truncating the file if it exists
@@ -563,9 +563,10 @@ declare namespace tjs {
      * const f = await tjs.open('file.txt', 'r');
      * ```
      * @param path The path to the file to be opened.
-     * @param mode Mode in which to open the file.
+     * @param flags Flags with which to open the file.
+     * @param mode File mode bits applied if the file is created. Defaults to `0o666`.
      */
-    function open(path: string, mode: string): Promise<FileHandle>;
+    function open(path: string, flags: string, mode?: number): Promise<FileHandle>;
 
     /**
      * Removes the directory at the given path.
@@ -578,7 +579,7 @@ declare namespace tjs {
      * Create a directory at the given path.
      *
      * @param path The path to of the directory to be created.
-     * @param mode The file mode for the new directory.
+     * @param mode The file mode for the new directory. Defaults to `0o777`.
      */
     function mkdir(path: string, mode?: number): Promise<void>;
 

--- a/src/fs.c
+++ b/src/fs.c
@@ -756,7 +756,7 @@ static JSValue tjs_fs_open(JSContext *ctx, JSValueConst this_val, int argc, JSVa
     flags = js__uv_open_flags(strflags, len);
     JS_FreeCString(ctx, strflags);
 
-    mode = 0;
+    mode = 0666;
     if (!JS_IsUndefined(argv[2]) && JS_ToInt32(ctx, &mode, argv[2])) {
         JS_FreeCString(ctx, path);
         return JS_EXCEPTION;


### PR DESCRIPTION
When opening files for creation, it is rarely desirable to have no file
mode bits set.
This change sets the default file mode bits to 0666, which is what NodeJS
and shells set it to, allowing the umask to reduce the permissions
appropriately.