### PR TITLE
os: add chdir() from libuv

### DIFF
--- a/docs/txikijs.d.ts
+++ b/docs/txikijs.d.ts
@@ -176,6 +176,11 @@ declare namespace tjs {
     function exit(code: number): void;
 
     /**
+     * Changes the current working directory.
+     */
+    function chdir(dir: string): void;
+
+    /**
      * Gets the current working directory.
      */
     function cwd(): string;

--- a/src/os.c
+++ b/src/os.c
@@ -189,6 +189,22 @@ static JSValue tjs_unsetenv(JSContext *ctx, JSValueConst this_val, int argc, JSV
     return JS_UNDEFINED;
 }
 
+static JSValue tjs_chdir(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
+    if (!JS_IsString(argv[0]))
+        return JS_ThrowTypeError(ctx, "expected a string");
+
+    const char *dir = JS_ToCString(ctx, argv[0]);
+    if (!dir)
+        return JS_EXCEPTION;
+
+    int r = uv_chdir(dir);
+    JS_FreeCString(ctx, dir);
+    if (r != 0)
+        return tjs_throw_errno(ctx, r);
+
+    return JS_UNDEFINED;
+}
+
 static JSValue tjs_cwd(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
     char buf[1024];
     size_t size = sizeof(buf);
@@ -459,6 +475,7 @@ static const JSCFunctionListEntry tjs_os_funcs[] = {
     TJS_CFUNC_DEF("getenv", 0, tjs_getenv),
     TJS_CFUNC_DEF("setenv", 2, tjs_setenv),
     TJS_CFUNC_DEF("unsetenv", 1, tjs_unsetenv),
+    TJS_CFUNC_DEF("chdir", 1, tjs_chdir),
     TJS_CFUNC_DEF("cwd", 0, tjs_cwd),
     TJS_CFUNC_DEF("homedir", 0, tjs_homedir),
     TJS_CFUNC_DEF("tmpdir", 0, tjs_tmpdir),

--- a/tests/test-fs.js
+++ b/tests/test-fs.js
@@ -64,9 +64,25 @@ async function chmod() {
     await tjs.rmdir(path);
 };
 
+async function chdir() {
+    const path = tjs.cwd();
+    const subDir = `test_chdir${tjs.pid}`;
+
+    await tjs.mkdir(subDir);
+
+    tjs.chdir(subDir);
+    assert.eq(tjs.cwd(), await tjs.realpath(path+ '/' + subDir));
+
+    tjs.chdir(path);
+    assert.eq(tjs.cwd(), path);
+
+    await tjs.rmdir(subDir);
+};
+
 (async () => {
     await readWrite();
     await mkstemp();
     await mkdir();
     await chmod();
+    await chdir();
 })();


### PR DESCRIPTION
I could use chdir() via FFI, but since it's cross-platform through libuv I figured it's a pretty easy inclusion into tjs.