### PR TITLE
stdio: only set blocking writes on stdout/err pipes on Windows

### DIFF
--- a/src/js/bundle.js
+++ b/src/js/bundle.js
@@ -15887,7 +15887,7 @@ function createStdioStream(fd) {
     case "pipe": {
       const handle = new core9.Pipe();
       handle.open(fd);
-      if (core9.platform === "windows") {
+      if (!isStdin && core9.platform === "windows") {
         handle.setBlocking(true);
       }
       return new StreamType(handle, type);

--- a/src/js/tjs/stdio.js
+++ b/src/js/tjs/stdio.js
@@ -75,7 +75,7 @@ function createStdioStream(fd) {
             handle.open(fd);
 
             // Do blocking writes on Windows.
-            if (core.platform === 'windows') {
+            if (!isStdin && core.platform === 'windows') {
                 handle.setBlocking(true);
             }
 


### PR DESCRIPTION
While the libuv API does this already, that is, calling it on a pipe we only read from has no effect, it makes it clearer when coming back to this code.