### PR TITLE
fs,streams: consolidate EOF marker

### DIFF
--- a/docs/txikijs.d.ts
+++ b/docs/txikijs.d.ts
@@ -9,11 +9,11 @@ declare namespace tjs {
      */
     interface Reader {
         /**
-         * Reads data into the given buffer. Resolves to the number of read bytes.
+         * Reads data into the given buffer. Resolves to the number of read bytes or null for EOF.
          *
          * @param buf Buffer to read data into.
          */
-        read(buf: Uint8Array): Promise<number>;
+        read(buf: Uint8Array): Promise<number|null>;
     }
 
     /**
@@ -420,12 +420,12 @@ declare namespace tjs {
     interface FileHandle {
         /**
          * Reads data into the given buffer at the given file offset. Returns
-         * the amount of read data.
+         * the amount of read data or null for EOF.
          *
          * @param buffer Buffer to read data into.
          * @param offset Offset in the file to read from.
          */
-        read(buffer: Uint8Array, offset?: number): Promise<number>;
+        read(buffer: Uint8Array, offset?: number): Promise<number|null>;
 
         /**
          * Writes data from the given buffer at the given file offset. Returns
@@ -835,7 +835,7 @@ declare namespace tjs {
     }
 
     interface Connection {
-        read(buf: Uint8Array): Promise<number>;
+        read(buf: Uint8Array): Promise<number|null>;
         write(buf: Uint8Array): Promise<number>;
         setKeepAlive(enable?: boolean): void;
         setNoDelay(enable?: boolean): void;

--- a/examples/echo-client-pipe.js
+++ b/examples/echo-client-pipe.js
@@ -10,7 +10,7 @@
     const buf = new Uint8Array(4096);
     while (true) {
         const nread = await p.read(buf);
-        if (!nread) {
+        if (nread === null) {
             console.log('connection closed!');
             break;
         }

--- a/examples/echo-client.js
+++ b/examples/echo-client.js
@@ -24,7 +24,7 @@ import { addr } from './utils.js';
     const buf = new Uint8Array(65536);
     while (true) {
         const nread = await conn.read(buf);
-        if (!nread) {
+        if (nread === null) {
             console.log('connection closed!');
             break;
         }

--- a/examples/echo-server-pipe.js
+++ b/examples/echo-server-pipe.js
@@ -8,7 +8,7 @@ async function handleConnection(conn) {
     const buf = new Uint8Array(4096);
     while (true) {
         const nread = await conn.read(buf);
-        if (!nread) {
+        if (nread === null) {
             console.log('connection closed!');
             break;
         }

--- a/examples/echo-server.js
+++ b/examples/echo-server.js
@@ -11,7 +11,7 @@ async function handleConnection(conn) {
     const buf = new Uint8Array(65536);
     while (true) {
         const nread = await conn.read(buf);
-        if (!nread) {
+        if (nread === null) {
             console.log('connection closed!');
             break;
         }

--- a/src/fs.c
+++ b/src/fs.c
@@ -294,6 +294,8 @@ static void uv__fs_req_cb(uv_fs_t *req) {
             f->path = JS_UNDEFINED;
             break;
         case UV_FS_READ:
+            arg = fr->req.result == 0 ? JS_NULL : JS_NewInt32(ctx, fr->req.result);
+            break;
         case UV_FS_WRITE:
             arg = JS_NewInt32(ctx, fr->req.result);
             break;

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -13495,7 +13495,7 @@ async function evalStdin() {
   const buf = [];
   while (true) {
     const n = await tjs.stdin.read(readBuf);
-    if (n === 0 || n === void 0) {
+    if (n === null) {
       break;
     }
     buf.push(...readBuf.subarray(0, n));
@@ -14254,7 +14254,7 @@ function readableStreamForHandle(handle) {
       const buf = controller.byobRequest.view;
       try {
         const nread = await handle.read(buf);
-        if (!nread) {
+        if (nread === null) {
           silentClose(handle);
           controller.close();
           controller.byobRequest.respond(0);
@@ -15679,7 +15679,7 @@ var Test = class {
     const buf = new Uint8Array(4096);
     while (true) {
       const nread = await s.read(buf);
-      if (!nread) {
+      if (nread === null) {
         break;
       }
       chunks.push(buf.slice(0, nread));

--- a/src/js/core/tjs/eval-stdin.js
+++ b/src/js/core/tjs/eval-stdin.js
@@ -10,7 +10,7 @@ export async function evalStdin() {
     while (true) {
         const n = await tjs.stdin.read(readBuf);
 
-        if (n === 0 || n === undefined) {
+        if (n === null) {
             break;
         }
 

--- a/src/js/core/tjs/run-tests.js
+++ b/src/js/core/tjs/run-tests.js
@@ -71,7 +71,7 @@ class Test {
         while (true) {
             const nread = await s.read(buf);
 
-            if (!nread) {
+            if (nread === null) {
                 break;
             }
 

--- a/src/js/core/tjs/stream-utils.js
+++ b/src/js/core/tjs/stream-utils.js
@@ -18,7 +18,7 @@ export function readableStreamForHandle(handle) {
             try {
                 const nread = await handle.read(buf);
 
-                if (!nread) {
+                if (nread === null) {
                     silentClose(handle);
                     controller.close();
                     controller.byobRequest.respond(0);

--- a/src/streams.c
+++ b/src/streams.c
@@ -126,7 +126,7 @@ static void uv__stream_read_cb(uv_stream_t *handle, ssize_t nread, const uv_buf_
     int is_reject = 0;
     if (nread < 0) {
         if (nread == UV_EOF) {
-            arg = JS_UNDEFINED;
+            arg = JS_NULL;
         } else {
             arg = tjs_new_error(ctx, nread);
             is_reject = 1;

--- a/tests/test-pipe.js
+++ b/tests/test-pipe.js
@@ -20,7 +20,7 @@ async function doEchoServer(server) {
     const buf = new Uint8Array(4096);
     while (true) {
         const nread = await conn.read(buf);
-        if (!nread) {
+        if (nread === null) {
             break;
         }
         conn.write(buf.slice(0, nread));

--- a/tests/test-tcp.js
+++ b/tests/test-tcp.js
@@ -14,7 +14,7 @@ async function doEchoServer(server) {
     const buf = new Uint8Array(4096);
     while (true) {
         const nread = await conn.read(buf);
-        if (!nread) {
+        if (nread === null) {
             break;
         }
         conn.write(buf.slice(0, nread));


### PR DESCRIPTION
Use null to mark EOF both for files and streams (tcp, pipes, etc).

Fixes: https://github.com/saghul/txiki.js/issues/337