### PR TITLE
Add build-essential to avoid build error

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ The following modules compose the standard library:
 If you didn't already clone this repository recursively, make sure you initialize these
 submodules with `git submodule update --init` before proceeding to the build. 
 
-Install dependencies (`libtool`, `makeinfo`, `openssl`, `libcurl`):
+Install dependencies (`libtool`, `makeinfo`, `openssl`, `libcurl`, `build-essential`):
 
 ```bash
- sudo apt install libtool texinfo libcurl4-openssl-dev
+ sudo apt install libtool texinfo libcurl4-openssl-dev build-essential
 ```
 
 


### PR DESCRIPTION
make

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.

After installing build-essential make builds successfully.