### PR TITLE
build: fix curl build warnings

### DIFF
--- a/src/curl-utils.c
+++ b/src/curl-utils.c
@@ -50,7 +50,7 @@ CURL *tjs__curl_easy_init(CURL *curl_h) {
     curl_easy_setopt(curl_h, CURLOPT_USERAGENT, TJS__UA_STRING);
     curl_easy_setopt(curl_h, CURLOPT_FOLLOWLOCATION, 1L);
     /* only allow HTTP */
-#if defined(CURLOPT_PROTOCOLS_STR)
+#if LIBCURL_VERSION_NUM >= 0x075500 /* added in 7.85.0 */
     curl_easy_setopt(curl_h, CURLOPT_PROTOCOLS_STR, "http,https");
     curl_easy_setopt(curl_h, CURLOPT_REDIR_PROTOCOLS_STR, "http,https");
 #else
@@ -58,7 +58,7 @@ CURL *tjs__curl_easy_init(CURL *curl_h) {
     curl_easy_setopt(curl_h, CURLOPT_REDIR_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
 #endif
     /* use TLS v1.1 or higher */
-#if defined(CURL_SSLVERSION_TLSv1_1)
+#if LIBCURL_VERSION_NUM >= 0x072200 /* added in 7.34.0 */
     curl_easy_setopt(curl_h, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_1);
 #endif
 

--- a/src/xhr.c
+++ b/src/xhr.c
@@ -278,8 +278,13 @@ static int curl__progress_cb(void *clientp,
     CHECK_NOT_NULL(x);
 
     if (x->ready_state == XHR_RSTATE_LOADING) {
+#if LIBCURL_VERSION_NUM >= 0x073700 /* added in 7.55.0 */
+        curl_off_t cl = -1;
+        curl_easy_getinfo(x->curl_h, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &cl);
+#else
         double cl = -1;
         curl_easy_getinfo(x->curl_h, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &cl);
+#endif
         JSContext *ctx = x->ctx;
         JSValue event = JS_NewObjectProto(ctx, JS_NULL);
         JS_DefinePropertyValueStr(ctx, event, "lengthComputable", JS_NewBool(ctx, cl > 0), JS_PROP_C_W_E);


### PR DESCRIPTION
The ifdefs were wrong since they are defined as enums, we need to version check against libcurl.