### PR TITLE
Some README improvements for types & added CI

### DIFF
--- a/.github/workflows/deploy-types.yml
+++ b/.github/workflows/deploy-types.yml
@@ -1,0 +1,25 @@
+name: Publish @txikijs/types
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          registry-url: https://registry.npmjs.org/
+      - name: Publish package
+        working-directory: ./docs
+        # ensure that the version of the tag is used for publishing
+        run: |
+          npm version ${GITHUB_REF_NAME#v}
+          npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Explore all the options:
 $ ./build/tjs --help
 ```
 
+For TS support see [@txikijs/types](https://www.npmjs.com/package/@txikijs/types).
+
 ## Features
 
 Support for the [ES2020] specification plus some ES2020+ features like top level await.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,10 +4,10 @@ To use the typings in your TS project, install it via `npm i @txikijs/types --sa
 
 Then either add `node_modules/@txikijs/types` to the `typeRoots` in your `tsconfig.json`:
 ```json
-"typeRoots": {
+"typeRoots": [
 	"node_modules/@txikijs/types",
 	"node_modules/@types"
-}
+]
 ```
 
 Or alternatively add `import type from '@txikijs/types';` somewhere in your code.

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,10 +1,13 @@
 {
   "name": "@txikijs/types",
-  "version": "23.1.1",
-  "description": "",
+  "description": "Typescript types for the txikijs runtime",
   "main": "",
   "types": "types/index.d.ts",
-  "keywords": ["tjs","txiki","txikijs"],
+  "keywords": [
+    "tjs",
+    "txiki",
+    "txikijs"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/saghul/txiki.js.git",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@txikijs/types",
-  "version": "23.1.0",
+  "version": "23.1.1",
   "description": "",
   "main": "",
   "types": "types/index.d.ts",
@@ -13,6 +13,7 @@
   "bugs": {
     "url": "https://github.com/saghul/txiki.js/issues"
   },
+  "homepage": "https://github.com/saghul/txiki.js/blob/master/docs/README.md",
   "author": "Saúl Ibarra Corretgé <s@saghul.net>",
   "license": "MIT",
   "files": [

--- a/docs/types/index.d.ts
+++ b/docs/types/index.d.ts
@@ -6,3 +6,5 @@
 /// <reference path="./ipaddr.d.ts" />
 /// <reference path="./path.d.ts" />
 /// <reference path="./uuid.d.ts" />
+
+export {};


### PR DESCRIPTION
Added CI.

You need to create a Github action secret `NPM_PUBLISH_TOKEN` containing the token from npm.

1. Goto npmjs.com and login
2. click on profile picture and Access Tokens
3. Click "Generate new Token" -> "Granular Access Token"
4. Enter a name and set Expiration
5. Under Packages & Scopes select "Read and Write", "Only select packages and scopes", select "@txikijs/types"

![image](https://github.com/saghul/txiki.js/assets/14139770/4d08864b-3abe-426c-93c5-8e4adf5aa667)

6. Click Generate Token & Copy it to github