### PR TITLE
core: workaround libuv change in behavior

### DIFF
--- a/src/private.h
+++ b/src/private.h
@@ -84,8 +84,7 @@ JSValue tjs_throw_errno(JSContext *ctx, int err);
 JSValue tjs_new_pipe(JSContext *ctx);
 uv_stream_t *tjs_pipe_get_stream(JSContext *ctx, JSValueConst obj);
 
-void tjs_execute_jobs(JSContext *ctx);
-
+void tjs__execute_jobs(JSContext *ctx);
 JSModuleDef *tjs__load_builtin(JSContext *ctx, const char *name);
 int tjs__load_file(JSContext *ctx, DynBuf *dbuf, const char *filename);
 JSModuleDef *tjs_module_loader(JSContext *ctx, const char *module_name, void *opaque);

--- a/src/timers.c
+++ b/src/timers.c
@@ -70,9 +70,8 @@ static void uv__timer_cb(uv_timer_t *handle) {
     TJSTimer *th = handle->data;
     CHECK_NOT_NULL(th);
 
-    /* Timer always executes before check phase in libuv,
-       so clear the microtask queue here before running setTimeout macrotasks */
-    tjs_execute_jobs(th->ctx);
+    /* Micro-tasks should run before timers. */
+    tjs__execute_jobs(th->ctx);
 
     call_timer(th);
     if (!th->interval)


### PR DESCRIPTION
In https://github.com/libuv/libuv/issues/3686 libuv changed when timers run respective to check handles.

Change the way we run the loop by running it again if necessary, untill there is no more work to do of the loop has been stopped.

Fixes: https://github.com/saghul/txiki.js/issues/443