### PR TITLE
build: fix libffi building to the wrong directory (https://github.com/saghul/txiki.js/issues/453)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ if(NOT USE_EXTERNAL_FFI AND NOT MINGW)
         libffi
         BUILD_IN_SOURCE 1
         SOURCE_DIR "${LIBFFI_SRC}"
-        CONFIGURE_COMMAND ./autogen.sh COMMAND ./configure --enable-static=yes --disable-shared
+        CONFIGURE_COMMAND ./autogen.sh COMMAND ./configure --enable-static=yes --disable-shared --disable-multi-os-directory
         BUILD_COMMAND make
         INSTALL_DIR ${TMP_INSTALL_DIR}
         INSTALL_COMMAND make DESTDIR=${TMP_INSTALL_DIR} install


### PR DESCRIPTION
On systems where `gcc --print-multi-os-directory` outputs something that is not `../lib`, Libffi installs to the wrong location (e.g. `lib64`) where CMake cannot find it and errors, breaking the build. This fix disables placing binaries in other places with the `--disable-multi-os-directory` configuration flag, forcing Libffi to install to `lib`.
This fix has no effect on systems where Libffi already installs to `lib`, and therefore does not break anything.