### PR TITLE
core: refactor how libuv companion objects are allocated

### DIFF
--- a/src/curl-utils.c
+++ b/src/curl-utils.c
@@ -24,6 +24,7 @@
 
 #include "curl-utils.h"
 
+#include "mem.h"
 #include "utils.h"
 #include "version.h"
 
@@ -150,7 +151,7 @@ typedef struct {
 static void uv__poll_close_cb(uv_handle_t *handle) {
     tjs_curl_poll_ctx_t *poll_ctx = handle->data;
     CHECK_NOT_NULL(poll_ctx);
-    free(poll_ctx);
+    tjs__free(poll_ctx);
 }
 
 static void uv__poll_cb(uv_poll_t *handle, int status, int events) {
@@ -182,7 +183,7 @@ static int curl__handle_socket(CURL *easy, curl_socket_t s, int action, void *us
             tjs_curl_poll_ctx_t *poll_ctx;
             if (!socketp) {
                 // Initialize poll handle.
-                poll_ctx = malloc(sizeof(*poll_ctx));
+                poll_ctx = tjs__malloc(sizeof(*poll_ctx));
                 if (!poll_ctx)
                     return -1;
                 CHECK_EQ(uv_poll_init_socket(&qrt->loop, &poll_ctx->poll, s), 0);

--- a/src/mem.c
+++ b/src/mem.c
@@ -48,6 +48,14 @@ void *tjs__malloc(size_t size) {
 #endif
 }
 
+void *tjs__mallocz(size_t size) {
+#ifdef TJS__HAS_MIMALLOC
+    return mi_calloc(1, size);
+#else
+    return calloc(1, size);
+#endif
+}
+
 void *tjs__calloc(size_t count, size_t size) {
 #ifdef TJS__HAS_MIMALLOC
     return mi_calloc(count, size);

--- a/src/mem.h
+++ b/src/mem.h
@@ -29,6 +29,7 @@
 
 size_t tjs__malloc_usable_size(const void *ptr);
 void *tjs__malloc(size_t size);
+void *tjs__mallocz(size_t size);
 void *tjs__calloc(size_t count, size_t size);
 void tjs__free(void *ptr);
 void *tjs__realloc(void *ptr, size_t size);


### PR DESCRIPTION
All native bindings are allocated and attached to the JS object in an opaque.

When what we attach is a native binding to a libuv handle there is a tricky situation: uv_close() is not synchronous, which means that we need to delay freeing the native object until the close callback was called. This is a problem when objects are freed as part of freeing the JS engine, since by the time the close callback is called the JS context and runtime have been freed.

In order to avoid this problem, allocate the memory for these "companion" objects with the tjs__ family of functions, which don't depend on the JS context.

This also allows us to refactor TJSFreeRuntime to a much more obvious flow. There is no need to walk and close all libuv handles, since they'll all be closed when the JS engine is terminated.