### PR TITLE
standalone: strip source when serializing bytecode

### DIFF
--- a/src/sys.c
+++ b/src/sys.c
@@ -194,7 +194,7 @@ static JSValue tjs_compile(JSContext *ctx, JSValue this_val, int argc, JSValue *
 
 static JSValue tjs_serialize(JSContext *ctx, JSValue this_val, int argc, JSValue *argv) {
     size_t len = 0;
-    int flags = JS_WRITE_OBJ_BYTECODE;
+    int flags = JS_WRITE_OBJ_BYTECODE | JS_WRITE_OBJ_STRIP_SOURCE;
     uint8_t *buf = JS_WriteObject(ctx, &len, argv[0], flags);
     if (!buf)
         return JS_EXCEPTION;


### PR DESCRIPTION
The resulting executable will be smaller and the source will be hidden. This is the same logic applied to all the bundled JS code in the runtime.