### PR TITLE
Revert "ci: temporatily exclude clang debug build"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,6 @@ jobs:
       matrix:
         buildType: [Debug, Release]
         compiler: [gcc, clang]
-        exclude:
-          - buildType: Debug
-            compiler: clang
     env:
       BUILDTYPE: ${{ matrix.buildType }}
     steps:


### PR DESCRIPTION
This reverts commit c317bf5ec243914d7ecb710af5f8b85260fe7dc4.