### PR TITLE
core: stop runtime on unhandled errors processing jobs

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -390,8 +390,12 @@ void tjs__execute_jobs(JSContext *ctx) {
     for (;;) {
         err = JS_ExecutePendingJob(JS_GetRuntime(ctx), &ctx1);
         if (err <= 0) {
-            if (err < 0)
-                tjs_dump_error(ctx1);
+            if (err < 0) {
+                TJSRuntime *qrt = TJS_GetRuntime(ctx);
+                CHECK_NOT_NULL(qrt);
+                TJS_Stop(qrt);
+            }
+
             break;
         }
     }

--- a/src/worker.c
+++ b/src/worker.c
@@ -73,10 +73,8 @@ static JSValue worker_eval(JSContext *ctx, int argc, JSValue *argv) {
     JSValue ret;
 
     specifier = JS_ToCString(ctx, argv[0]);
-    if (!specifier) {
-        tjs_dump_error(ctx);
+    if (!specifier)
         goto error;
-    }
 
     if (!JS_IsUndefined(argv[1])) {
         size_t len;
@@ -89,7 +87,6 @@ static JSValue worker_eval(JSContext *ctx, int argc, JSValue *argv) {
     JS_FreeCString(ctx, specifier);
 
     if (JS_IsException(ret)) {
-        tjs_dump_error(ctx);
         JS_FreeValue(ctx, ret);
         goto error;
     }


### PR DESCRIPTION
Also avoid dumping errors unnecessarily, they'll be dumped when the runtime stops.