### PR TITLE
add release ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: Releases
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build-windows-x86_64:
+    runs-on: windows-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          path-type: inherit
+          install: >-
+            curl
+            make
+            cmake
+
+      - shell: msys2 {0}
+        run: |
+          pacman -S mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake mingw-w64-x86_64-make mingw-w64-x86_64-curl libcurl openssl-devel libcurl-devel autoconf texinfo mingw-w64-x86_64-libtool --noconfirm
+          make
+
+          mkdir txiki-windows-x86_64
+          cp build/tjs.exe txiki-windows-x86_64/tjs.exe
+          cd txiki-windows-x86_64
+          ldd tjs.exe | grep -v '=> /c/Windows/.*' | awk '{print $3}' | xargs -I '{}' cp -v '{}' .
+
+      - name: Upload windows x86_64 Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: txiki-windows-x86_64
+          path: txiki-windows-x86_64
+
+  build-macos:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: build macos-latest
+        run: |
+          brew install cmake autoconf automake libtool texinfo
+          make BUILD_MACOS_MULTIARCH=1
+
+          mkdir txiki-macos
+          cp build/tjs txiki-macos/tjs
+
+      - name: Upload macos Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: txiki-macos
+          path: txiki-macos
+
+  release:
+    needs: [build-windows-x86_64, build-macos]
+    name: release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: txiki-*
+          merge-multiple: false
+
+      - name: compress
+        run: |
+          cd dist
+          for dir in */; do zip -r "${dir%/}.zip" "$dir"; done
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: "dist/*.zip"


### PR DESCRIPTION
Support build on windows-x86, macos-x86, macos-arm64 

For Windows platform, all dynamic libraries required by tjs are packaged

Only tested in Windows environment https://github.com/ahaoboy/txiki.js/releases