### PR TITLE
core: simplify unhandled promise rejection handling

### DIFF
--- a/src/private.h
+++ b/src/private.h
@@ -49,6 +49,7 @@ struct TJSRuntime {
     } jobs;
     uv_async_t stop;
     bool is_worker;
+    bool freeing;
     struct {
         CURLM *curlm_h;
         uv_timer_t timer;
@@ -60,6 +61,10 @@ struct TJSRuntime {
         TJSTimer *timers;
         int64_t next_timer;
     } timers;
+    struct {
+        JSValue promise_event_ctor;
+        JSValue dispatch_event_func;
+    } builtins;
 };
 
 void tjs__mod_dns_init(JSContext *ctx, JSValue ns);


### PR DESCRIPTION
Cache the event constructor and the dispatchEvent function so we can call them easily when new events need to be emitted from C code.