### PR TITLE
fix low verion gcc build err

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -41,15 +41,15 @@ typedef struct {
 } tjs_builtin_t;
 
 static tjs_builtin_t builtins[] = {
-    { "tjs:assert", tjs__assert, tjs__assert_size },
-    { "tjs:ffi", tjs__ffi, tjs__ffi_size },
-    { "tjs:getopts", tjs__getopts, tjs__getopts_size },
-    { "tjs:hashing", tjs__hashing, tjs__hashing_size },
-    { "tjs:ipaddr", tjs__ipaddr, tjs__ipaddr_size },
-    { "tjs:path", tjs__path, tjs__path_size },
-    { "tjs:posix-socket", tjs__posix_socket, tjs__posix_socket_size },
-    { "tjs:sqlite", tjs__sqlite, tjs__sqlite_size },
-    { "tjs:uuid", tjs__uuid, tjs__uuid_size },
+    { "tjs:assert", tjs__assert, sizeof(tjs__assert) },
+    { "tjs:ffi", tjs__ffi, sizeof(tjs__ffi) },
+    { "tjs:getopts", tjs__getopts, sizeof(tjs__getopts) },
+    { "tjs:hashing", tjs__hashing, sizeof(tjs__hashing) },
+    { "tjs:ipaddr", tjs__ipaddr, sizeof(tjs__ipaddr) },
+    { "tjs:path", tjs__path, sizeof(tjs__path) },
+    { "tjs:posix-socket", tjs__posix_socket, sizeof(tjs__posix_socket) },
+    { "tjs:sqlite", tjs__sqlite, sizeof(tjs__sqlite) },
+    { "tjs:uuid", tjs__uuid, sizeof(tjs__uuid) },
     { NULL, NULL, 0 },
 };
 


### PR DESCRIPTION
`/home/wangyang/cross/.xmake/cache/packages/2408/t/txiki.js/v24.6.0/source/txiki.js/src/builtins.c:44:34: error: initializer element is not constant
     { "tjs:assert", tjs__assert, tjs__assert_size },
                                  ^~~~~~~~~~~~~~~~
/home/wangyang/cross/.xmake/cache/packages/2408/t/txiki.js/v24.6.0/source/txiki.js/src/builtins.c:44:34: note: (near initialization for ‘builtins[0].data_size’)
/home/wangyang/cross/.xmake/cache/packages/2408/t/txiki.js/v24.6.0/source/txiki.js/src/builtins.c:45:28: error: initializer element is not constant
     { "tjs:ffi", tjs__ffi, tjs__ffi_size },
                            ^~~~~~~~~~~~~
/home/wangyang/cross/.xmake/cache/packages/2408/t/txiki.js/v24.6.0/source/txiki.js/src/builtins.c:45:28: note: (near initialization for ‘builtins[1].data_size’)
/home/wangyang/cross/.xmake/cache/packages/2408/t/txiki.js/v24.6.0/source/txiki.js/src/builtins.c:46:36: error: initializer element is not constant
     { "tjs:getopts", tjs__getopts, tjs__getopts_size },
                                    ^~~~~~~~~~~~~~~~~
/home/wangyang/cross/.xmake/cache/packages/2408/t/txiki.js/v24.6.0/source/txiki.js/src/builtins.c:46:36: note: (near initialization for ‘builtins[2].data_size’)
/home/wangyang/cross/.xmake/cache/packages/2408/t/txiki.js/v24.6.0/source/txiki.js/src/builtins.c:47:36: error: initializer element is not constant
     { "tjs:hashing", tjs__hashing, tjs__hashing_size },
                                    ^~~~~~~~~~~~~~~~~
/home/wangyang/cross/.xmake/cache/packages/2408/t/txiki.js/v24.6.0/source/txiki.js/src/builtins.c:47:36: note: (near initialization for ‘builtins[3].data_size’)
/home/wangyang/cross/.xmake/cache/packages/2408/t/txiki.js/v24.6.0/source/txiki.js/src/builtins.c:48:34: error: initializer element is not constant
     { "tjs:ipaddr", tjs__ipaddr, tjs__ipaddr_size },
                                  ^~~~~~~~~~~~~~~~
/home/wangyang/cross/.xmake/cache/packages/2408/t/txiki.js/v24.6.0/source/txiki.js/src/builtins.c:48:34: note: (near initialization for ‘builtins[4].data_size’)
/home/wangyang/cross/.xmake/cache/packages/2408/t/txiki.js/v24.6.0/source/txiki.js/src/builtins.c:49:30: error: initializer element is not constant
     { "tjs:path", tjs__path, tjs__path_size },
                              ^~~~~~~~~~~~~~
/home/wangyang/cross/.xmake/cache/packages/2408/t/txiki.js/v24.6.0/source/txiki.js/src/builtins.c:49:30: note: (near initialization for ‘builtins[5].data_size’)
/home/wangyang/cross/.xmake/cache/packages/2408/t/txiki.js/v24.6.0/source/txiki.js/src/builtins.c:50:46: error: initializer element is not constant
     { "tjs:posix-socket", tjs__posix_socket, tjs__posix_socket_size },
                                              ^~~~~~~~~~~~~~~~~~~~~~
/home/wangyang/cross/.xmake/cache/packages/2408/t/txiki.js/v24.6.0/source/txiki.js/src/builtins.c:50:46: note: (near initialization for ‘builtins[6].data_size’)
/home/wangyang/cross/.xmake/cache/packages/2408/t/txiki.js/v24.6.0/source/txiki.js/src/builtins.c:51:34: error: initializer element is not constant
     { "tjs:sqlite", tjs__sqlite, tjs__sqlite_size },
                                  ^~~~~~~~~~~~~~~~
/home/wangyang/cross/.xmake/cache/packages/2408/t/txiki.js/v24.6.0/source/txiki.js/src/builtins.c:51:34: note: (near initialization for ‘builtins[7].data_size’)
/home/wangyang/cross/.xmake/cache/packages/2408/t/txiki.js/v24.6.0/source/txiki.js/src/builtins.c:52:30: error: initializer element is not constant
     { "tjs:uuid", tjs__uuid, tjs__uuid_size },
                              ^~~~~~~~~~~~~~
/home/wangyang/cross/.xmake/cache/packages/2408/t/txiki.js/v24.6.0/source/txiki.js/src/builtins.c:52:30: note: (near initialization for ‘builtins[8].data_size’)`

low version gcc will trig error like [this](https://stackoverflow.com/questions/3025050/error-initializer-element-is-not-constant-when-trying-to-initialize-variable-w)