### PR TITLE
doc: add libltdl-dev for linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,15 +127,15 @@ The following modules compose the standard library:
 
 *NOTE:* The txiki.js build depends on a number of git submodules ([libffi], [libuv] and [wasm3]).
 If you didn't already clone this repository recursively, make sure you initialize these
-submodules with `git submodule update --init` before proceeding to the build. 
+submodules with `git submodule update --init` before proceeding to the build.
 
 ### GNU/Linux
 
-Install dependencies (`libcurl`, `build-essential`, `cmake`, `makeinfo`, `autoreconf`, `libtool`):
+Install dependencies (`libcurl`, `build-essential`, `cmake`, `makeinfo`, `autoreconf`, `libtool`, `libltdl-dev`):
 
 ```bash
 # On Debian / Ubuntu
-sudo apt install libcurl4-openssl-dev build-essential cmake autoconf texinfo libtool
+sudo apt install libcurl4-openssl-dev build-essential cmake autoconf texinfo libtool libltdl-dev
 ```
 
 ### macOS


### PR DESCRIPTION

Compiling on ubuntu24.04 with github runner will give an error

```
configure.ac:215: error: possibly undefined macro: LT_SYS_SYMBOL_USCORE
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
autoreconf: error: /usr/bin/autoconf failed with exit status: 1
```


https://github.com/libffi/libffi/issues/210

It seems that libuv and libffi require libltdl-dev

```
sudo apt-get install libltdl-dev
```
