### PR TITLE
update sqlite3 cmake version

### DIFF
--- a/deps/sqlite3/CMakeLists.txt
+++ b/deps/sqlite3/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.5)
 
 project(sqlite3 LANGUAGES C)
 


### PR DESCRIPTION
Current cmake version (v4) does not support <3.5 anymore, so adjust the minimum version. This should fix some CI jobs.