### PR TITLE
Add WebSocket server

### DIFF
--- a/src/js/polyfills/ws-server.js
+++ b/src/js/polyfills/ws-server.js
@@ -1,0 +1,229 @@
+class WebSocketConnection {
+  readable;
+  writable;
+  writer;
+  buffer = new Uint8Array(0);
+  closed = !1;
+  opcodes = { TEXT: 1, BINARY: 2, PING: 9, PONG: 10, CLOSE: 8 };
+  constructor(readable, writable) {
+    this.readable = readable;
+    if (writable instanceof WritableStreamDefaultWriter) {
+      this.writer = writable;
+    } else if (writable instanceof WritableStream) {
+      this.writable = writable;
+      this.writer = this.writable.getWriter();
+    } else {
+      this.writer = writable;
+    }
+  }
+  async processWebSocketStream() {
+    try {
+      for await (const frame of this.readable) {
+        const uint8 = new Uint8Array(this.buffer.length + frame.length);
+        uint8.set(this.buffer, 0);
+        uint8.set(frame, this.buffer.length);
+        this.buffer = uint8;
+        this.processFrame();
+      }
+      console.log("WebSocket connection closed.");
+    } catch (e) {
+      console.log(e);
+      this.writer.close().catch(console.log);
+    }
+  }
+  writeFrame(opcode, payload) {
+    this.writer.write(this.encodeMessage(opcode, payload));
+  }
+  send(obj) {
+    let opcode, payload;
+    if (obj instanceof Uint8Array) {
+      opcode = this.opcodes.BINARY;
+      payload = obj;
+    } else if (typeof obj == "string") {
+      opcode = this.opcodes.TEXT;
+      payload = obj;
+    } else {
+      throw new Error("Cannot send object. Must be string or Uint8Array");
+    }
+    this.writeFrame(opcode, payload);
+  }
+  close(code, reason) {
+    const opcode = this.opcodes.CLOSE;
+    let buffer;
+    if (code) {
+      buffer = new Uint8Array(reason.length + 2);
+      const view = new DataView(buffer.buffer);
+      view.setUint16(0, code, !1);
+      buffer.set(reason, 2);
+    } else {
+      buffer = new Uint8Array(0);
+    }
+    console.log({ opcode });
+    this.writeFrame(opcode, buffer);
+    this.writer.close();
+    this.closed = !0;
+  }
+  processFrame() {
+    let length, maskBytes;
+    const buf = this.buffer, view = new DataView(buf.buffer);
+    if (buf.length < 2) {
+      return !1;
+    }
+    let idx = 2,
+      b1 = view.getUint8(0),
+      fin = b1 & 128,
+      opcode = b1 & 15,
+      b2 = view.getUint8(1),
+      mask = b2 & 128;
+    length = b2 & 127;
+    if (length > 125) {
+      if (buf.length < 8) {
+        return !1;
+      }
+      if (length == 126) {
+        length = view.getUint16(2, !1);
+        idx += 2;
+      } else if (length == 127) {
+        if (view.getUint32(2, !1) != 0) {
+          this.close(1009, "");
+        }
+        length = view.getUint32(6, !1);
+        idx += 8;
+      }
+    }
+    if (buf.length < idx + 4 + length) {
+      return !1;
+    }
+    maskBytes = buf.subarray(idx, idx + 4);
+    idx += 4;
+    let payload = buf.subarray(idx, idx + length);
+    payload = this.unmask(maskBytes, payload);
+    // Do stuff with payload from client/peer
+    // console.log(`Got payload from client/peer`);
+    // Here input is echoed to output
+    this.handleFrame(opcode, payload);
+    this.buffer = buf.subarray(idx + length);
+    if (this.buffer.length === 0) {
+      // console.log(`this.buffer.length: ${this.buffer.length}.`);
+      return !1;
+    }
+    return !0;
+  }
+  handleFrame(opcode, buffer) {
+    // console.log({ opcode, length: buffer.length });
+    const view = new DataView(buffer.buffer);
+    let payload;
+    switch (opcode) {
+      case this.opcodes.TEXT:
+        payload = buffer;
+        this.writeFrame(opcode, payload);
+        break;
+      case this.opcodes.BINARY:
+        payload = buffer;
+        this.writeFrame(opcode, payload);
+        break;
+      case this.opcodes.PING:
+        this.writeFrame(this.opcodes.PONG, buffer);
+        break;
+      case this.opcodes.PONG:
+        break;
+      case this.opcodes.CLOSE:
+        let code, reason;
+        if (buffer.length >= 2) {
+          code = view.getUint16(0, !1);
+          reason = (new TextDecoder()).decode(buffer);
+        }
+        this.close(code, reason);
+        console.log("Close opcode.");
+        break;
+      default:
+        this.close(1002, "unknown opcode");
+    }
+  }
+  unmask(maskBytes2, data) {
+    let payload = new Uint8Array(data.length);
+    for (var i = 0; i < data.length; i++) {
+      payload[i] = maskBytes2[i % 4] ^ data[i];
+    }
+    return payload;
+  }
+  encodeMessage(opcode, payload) {
+    let buf, b1 = 128 | opcode, b2 = 0, length = payload.length;
+    if (length < 126) {
+      buf = new Uint8Array(payload.length + 2 + 0);
+      const view = new DataView(buf.buffer);
+      b2 |= length;
+      view.setUint8(0, b1);
+      view.setUint8(1, b2);
+      buf.set(payload, 2);
+    } else if (length < 65536) {
+      buf = new Uint8Array(payload.length + 2 + 2);
+      const view = new DataView(buf.buffer);
+      b2 |= 126;
+      view.setUint8(0, b1);
+      view.setUint8(1, b2);
+      view.setUint16(2, length);
+      buf.set(payload, 4);
+    } else {
+      buf = new Uint8Array(payload.length + 2 + 8);
+      const view = new DataView(buf.buffer);
+      b2 |= 127;
+      view.setUint8(0, b1);
+      view.setUint8(1, b2);
+      view.setUint32(2, 0, !1);
+      view.setUint32(6, length, !1);
+      buf.set(payload, 10);
+    }
+    return buf;
+  }
+  static KEY_SUFFIX = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+  static async hashWebSocketKey(secKeyWebSocket, writable) {
+    // Use Web Cryptography API crypto.subtle where defined
+    if (globalThis.crypto.subtle) {
+      const encoder = new TextEncoder(),
+        key = btoa(
+          [
+            ...new Uint8Array(
+              await crypto.subtle.digest(
+                "SHA-1",
+                encoder.encode(
+                  `${secKeyWebSocket}${WebSocketConnection.KEY_SUFFIX}`,
+                ),
+              ),
+            ),
+          ].map((s) => String.fromCodePoint(s)).join(""),
+        );
+      const header = `HTTP/1.1 101 Web Socket Protocol Handshake\r
+Upgrade: WebSocket\r
+Connection: Upgrade\r
+sec-websocket-accept: ` + key + `\r
+\r
+`;
+      return writable instanceof WritableStream
+        ? (new Response(header)).body.pipeTo(writable, { preventClose: !0 })
+        : writable.write(encoder.encode(header));
+    } else {
+      // txiki.js does not support Web Cryptography API crypto.subtle
+      // Use txiki.js specific tjs:hashing or 
+      // https://raw.githubusercontent.com/kawanet/sha1-uint8array/main/lib/sha1-uint8array.ts
+      const { createHash } = await import("tjs:hashing"); 
+      const encoder = new TextEncoder();
+      const hash = createHash("sha1").update(
+        `${secKeyWebSocket}${WebSocketConnection.KEY_SUFFIX}`,
+      ).bytes();
+      const key = btoa(
+        String.fromCodePoint(...hash),
+      );
+      const header = "HTTP/1.1 101 Web Socket Protocol Handshake\r\n" +
+        "Upgrade: WebSocket\r\n" +
+        "Connection: Upgrade\r\n" +
+        "sec-websocket-accept: " + key + "\r\n\r\n";
+      const encoded = encoder.encode(header);
+      return writable instanceof WritableStream
+        ? new Response(encode).body.pipeTo(writable, { preventClose: !0 })
+        : writable.write(encoded);
+    }
+  }
+}
+
+export { WebSocketConnection };


### PR DESCRIPTION
Interoperability is all over the place. 

For WebSocket clients

- Chromium 138 Developer Build (Linux)

{ conn: { [Symbol(kHandle)]: {} } }
{ opcode: 8 }
Close opcode.
TypeError: Parameter 1 is required in 'respond'.
    at $ (polyfills.js:28:14849)
    at respond (polyfills.js:28:21853)
    at pull (core.js{ conn: { [Symbol(kHandle)]: {} } }
{ opcode: 8 }
Close opcode.
WebSocket client connection closed
Error: EPIPE: broken pipe
:1:11961)


- Firefox Nightly 140.0a1 (2025-05-07) (64-bit)

Works with 127.0.0.1:8080

Does not work with 0.0.0.0:8080

- Bun 1.2.13

Works with builtin or Undici. Always causes broken pipe in tjs.

{ conn: { [Symbol(kHandle)]: {} } }
{ opcode: 8 }
Close opcode.
WebSocket client connection closed
Error: EPIPE: broken pipe

- Deno 2.3.1+d372c0d (canary, release, x86_64-unknown-linux-gnu)

Does nothing. Using builtin or Undici. 0.0.0.0, 127.0.0.1, or localhost.

- Node.js v24.0.0-nightly202505066102159fa1

Does nothing. Using builtin or Undici. 0.0.0.0, 127.0.0.1, or localhost.

For WebSocketStream clients

- Chromium 138 Developer Build (Linux)

Works.

writer.close() does not cause broken pipe. A different error.  Server does not exit. 

TypeError: Parameter 1 is required in 'respond'.
    at $ (polyfills.js:28:14849)
    at respond (polyfills.js:28:21853)
    at pull (core.js:1:11961)

- Deno 

Does nothing. Using builtin or Undici. 0.0.0.0, 127.0.0.1, or localhost.

- Node.js 

Does nothing. Using builtin or Undici. 0.0.0.0, 127.0.0.1, or localhost.

`websocket-client.js`. Echo 1 MB.

```
// import { WebSocket } from "undici";

var ws = new WebSocket("ws://127.0.0.1:8080");
ws.binaryType = "arraybuffer";
ws.addEventListener("open", (e) => {
  console.log(e);
  write();
});
ws.addEventListener("close", (e) => {
  console.log(e);
});
ws.addEventListener("message", (e) => {
  const v = e.data;
  if (typeof v === "string") {
    console.log(v);
  } else {
    const decoded = decoder.decode(v, {
      stream: true,
    });
    console.log(len += v.byteLength, [...decoded].every((s) => s === "a"));
  }
  if (len === data.buffer.byteLength) {
    console.log(ws.bufferedAmount);
    ws.close();
  }
});
ws.addEventListener("error", (e) => {
  console.log(e);
});

var len = 0;
var encoder = new TextEncoder();
var decoder = new TextDecoder();
var data = new Uint8Array(1024 ** 2).fill(97);
var len = 0;

function write() {
  for (let i = 0; i < data.length; i += 65536) {
    try {
      console.log(ws.bufferedAmount);
      ws.send(data.subarray(i, i + 65536));
    } catch (e) {
      console.warn(e);
    }
  }
}
```

`websocket-stream-client.js`. Echo 7 MB.

```
// Only aborts *before* the handshake
import { WebSocketStream } from "undici";
// Only aborts *before* the handshake
var abortable = new AbortController();
var {
  signal,
} = abortable;
var wss = new WebSocketStream("ws://0.0.0.0:8080", {
  signal
});
console.log(wss);

var {
  readable,
  writable,
} = await wss.opened.catch(console.warn);
wss.closed.then(() => console.log("WebSocketStream closed.")).catch((e) => {
  console.log(e);
});
console.log(readable);
var writer = writable.getWriter();
var reader = readable.getReader();
var len = 0;
var encoder = new TextEncoder();
var decoder = new TextDecoder();
var data = new Uint8Array(1024 ** 2 * 7).fill(97);
var len = 0;
for (let i = 0; i < data.length; i += 65536) {
  try {
    await writer.ready;
    writer.write(data.subarray(i, i + 65536));
    // console.log(writer.desiredSize);
    const {
      value: v,
      done,
    } = await reader.read();
    if (typeof v === "string") {
      console.log(v);
    } else {
      const decoded = decoder.decode(v, {
        stream: true,
      });
      console.log(
        len += v.byteLength,
        v,
        [...decoded].every((s) => s === "a"),
      );
    }
  } catch (e) {
    console.warn(e);
  }
}
console.assert(len === data.buffer.byteLength, [len, data.buffer.byteLength]);
console.log(len, data.buffer.byteLength);
await writer.write("Text").then(() => reader.read()).then(console.log).catch(
  console.warn,
);
await writer.close();
```

Usage in `tjs` runtime `tjs run tjs-websocket-server.js`

```
import { WebSocketConnection } from "./websocket-server.js";

const decoder = new TextDecoder();

const listener = await tjs.listen("tcp", "0.0.0.0", "8080");
const { family, ip, port } = listener.localAddress;
console.log(
  `${navigator.userAgent} WebSocket server listening on family: ${family}, ip: ${ip}, port: ${port}`,
);

// TODO: Don't exit loop when broken pipe happens (Bun 1.2.13)
while (true) {
  try {
    const conn = await listener.accept();
    console.log({ conn });
    const writer = conn.writable.getWriter();
    const { readable: wsReadable, writable: wsWritable } = new TransformStream(),
      wsWriter = wsWritable.getWriter();
    let ws;
    for await (const value of conn.readable) {
      const request = decoder.decode(value);
      if (request.includes("Upgrade: websocket")) {
        const [key] = request.match(/(?<=Sec-WebSocket-Key: ).+/i);
        const handshake = await WebSocketConnection.hashWebSocketKey(
          key,
          writer,
        );
        ws = new WebSocketConnection(wsReadable, writer)
          .processWebSocketStream().catch((e) => {
            throw e;
          });
      } else {
        await wsWriter.ready;
        await wsWriter.write(new Uint8Array(value));
      }
    }

    console.log("WebSocket client connection closed");
    // await wsWriter.close();
  } catch (e) {
    // listener.close();
    console.log(e);
/*

{ conn: { [Symbol(kHandle)]: {} } }
{ opcode: 8 }
Close opcode.
WebSocket client connection closed
txiki.js/24.12.0 WebSocket server listening on family: 4, ip: 0.0.0.0, port: 8080
Error: EPIPE: broken pipe

Or

{ conn: { [Symbol(kHandle)]: {} } }
{ opcode: 8 }
Close opcode.
TypeError: Parameter 1 is required in 'respond'.
    at $ (polyfills.js:28:14849)
    at respond (polyfills.js:28:21853)
    at pull (core.js:1:11961)

Unpredictable which will happen, or not
*/
  } finally {
    continue;
  }
}
```