### PR TITLE
feat: enable network request compressing & decompressing

### DIFF
--- a/src/xhr.c
+++ b/src/xhr.c
@@ -349,6 +349,11 @@ static JSValue tjs_xhr_constructor(JSContext *ctx, JSValue new_target, int argc,
     curl_easy_setopt(x->curl_h, CURLOPT_WRITEDATA, x);
     curl_easy_setopt(x->curl_h, CURLOPT_HEADERFUNCTION, curl__header_cb);
     curl_easy_setopt(x->curl_h, CURLOPT_HEADERDATA, x);
+#if LIBCURL_VERSION_NUM >= 0x071506 /* renamed from ENCODING to ACCEPT_ENCODING in 7.21.6 */
+    curl_easy_setopt(x->curl_h, CURLOPT_ACCEPT_ENCODING, "");
+#else
+    curl_easy_setopt(x->curl_h, CURLOPT_ENCODING, "");
+#endif
 
     JS_SetOpaque(obj, x);
     return obj;


### PR DESCRIPTION
Setting [CURLOPT_ACCEPT_ENCODING](https://curl.se/libcurl/c/CURLOPT_ACCEPT_ENCODING.html) to an empty string will enable compressing and decompressing of cURL, which will:
1. Automatically compress the request body and request server respond with a compressed body to reduce network traffic.
2. Automatically decompress the response body according to the `content-encoding` header in the response.
3. Make curl decompressing response body automatically when users set the `accept-encoding` header manually (some SDKs sign requests with headers, making deleting the `accept-encoding` header impossible).  
  
Without setting `CURLOPT_ACCEPT_ENCODING`, cURL will not decompress any response even a `content-encoding` header is set, enforcing users handle decompressing in JS with a poor performance.