### PR TITLE
fix: naive use of cstring pointer as a typed array buffer pointer resulting in a crash on gc in #739 - expose stringToBuffer

### DIFF
--- a/src/mod_ffi.c
+++ b/src/mod_ffi.c
@@ -856,8 +856,9 @@ static JSValue js_to_cstring(JSContext *ctx, JSValue this_val, int argc, JSValue
 
     size_t len = 0;
     const void *buf = JS_ToCStringLen(ctx, &len, argv[0]);
-    if (!buf)
+    if (!buf) {
         return JS_EXCEPTION;
+    }
 
     JSValue result = JS_NewUint8ArrayCopy(ctx, buf, len);
 


### PR DESCRIPTION
This is a fix for #739 . My assumption was that JS_ToCString was returning c managed memory buffer - so handing it over to the js runtime by using it as a backing buffer for a typed array would be fine.. but as it turns out JS_ToCString do actually return a memory buffer to a cstring, BUT this buffer is actually already a backing buffer of a JSString allocated in this function.. so GCing the JSString and the TypedArray resulted in double free and a crash. So the updated code now 
- uses JS_NewUint8ArrayCopy that copies the buffer from the JSString
- frees the CString (JSString)
- hands over the Uint8Array to the calling code

This time I did my homework (hopefully) - I tested the code both for stability and if it is leaking memory with the help of `JS_SetDumpFlags(rt, JS_DUMP_LEAKS); JS_SetDumpFlags(rt, JS_DUMP_MEM);` and `ENABLE_DUMPS` - no difference in memory usage at the end of a test after no calls vs 10.. 100.. and 1000 calls to `ffi.bufferToString(ffi.stringToBuffer(longString)` and no leaked objects and strings reported.