### PR TITLE
core: add support for import attributes

### DIFF
--- a/src/curl-utils.c
+++ b/src/curl-utils.c
@@ -102,9 +102,6 @@ int tjs_curl_load_http(DynBuf *dbuf, const char *url) {
     /* cleanup curl stuff */
     curl_easy_cleanup(curl_handle);
 
-    /* curl won't null terminate the memory, do it ourselves */
-    dbuf_putc(dbuf, '\0');
-
     return r;
 }
 

--- a/src/private.h
+++ b/src/private.h
@@ -101,7 +101,8 @@ uv_stream_t *tjs_pipe_get_stream(JSContext *ctx, JSValue obj);
 void tjs__execute_jobs(JSContext *ctx);
 JSModuleDef *tjs__load_builtin(JSContext *ctx, const char *name);
 int tjs__load_file(JSContext *ctx, DynBuf *dbuf, const char *filename);
-JSModuleDef *tjs_module_loader(JSContext *ctx, const char *module_name, void *opaque);
+int tjs_module_attr_checker(JSContext *ctx, void *opaque, JSValueConst attributes);
+JSModuleDef *tjs_module_loader(JSContext *ctx, const char *module_name, void *opaque, JSValueConst attributes);
 char *tjs_module_normalizer(JSContext *ctx, const char *base_name, const char *name, void *opaque);
 
 int js_module_set_import_meta(JSContext *ctx, JSValue func_val, bool use_realpath, bool is_main);

--- a/src/vm.c
+++ b/src/vm.c
@@ -288,7 +288,7 @@ TJSRuntime *TJS_NewRuntimeInternal(bool is_worker, TJSRunOptions *options) {
     qrt->stop.data = qrt;
 
     /* loader for ES modules */
-    JS_SetModuleLoaderFunc(rt, tjs_module_normalizer, tjs_module_loader, qrt);
+    JS_SetModuleLoaderFunc2(rt, tjs_module_normalizer, tjs_module_loader, tjs_module_attr_checker, qrt);
 
     /* unhandled promise rejection tracker */
     JS_SetHostPromiseRejectionTracker(rt, tjs__promise_rejection_tracker, NULL);

--- a/tests/test-import-json.js
+++ b/tests/test-import-json.js
@@ -1,5 +1,5 @@
 import assert from 'tjs:assert';
-import data from './fixtures/data.json';
+import data from './fixtures/data.json' with { type: "json" };
 
 
 assert.eq(data.widget.debug, 'on', 'string data matches');


### PR DESCRIPTION
Refactor the module loader to check the attributes (if present) and use
the new APIs for simpler JSON module loading.
