### PR TITLE
timers: avoid calling a timer handler if handle closing

### DIFF
--- a/src/timers.c
+++ b/src/timers.c
@@ -80,6 +80,11 @@ static void uv__timer_cb(uv_timer_t *handle) {
     /* Micro-tasks should run before timers. */
     tjs__execute_jobs(th->ctx);
 
+    /* It's possible our timer was scheduled to run but was destroyed by another one. */
+    if (uv_is_closing((uv_handle_t *) handle)) {
+        return;
+    }
+
     tjs_call_handler(th->ctx, th->func, th->argc, th->argv);
 
     if (!th->interval) {


### PR DESCRIPTION
It's possible timerA stops timerB when timerB is already scheduled to
run.

Since we set the handler function to undefined as part of closing it,
this will trigger a TypeError and the event loop will be stopped.
