### PR TITLE
build: improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,28 +13,28 @@ JOBS := 4
 endif
 
 TJS=$(BUILD_DIR)/tjs
-QJSC=$(BUILD_DIR)/tjsc
+TJSC=$(BUILD_DIR)/tjsc
 STDLIB_MODULES=$(wildcard src/js/stdlib/*.js)
 ESBUILD?=npx esbuild
 ESBUILD_PARAMS_COMMON=--target=es2023 --platform=neutral --format=esm --main-fields=main,module
 ESBUILD_PARAMS_MINIFY=--minify --keep-names
-QJSC_PARAMS_STIP=-s
+TJSC_PARAMS_STIP=-s
 JS_NO_STRIP?=0
 
 ifeq ($(JS_NO_STRIP),1)
 	ESBUILD_PARAMS_MINIFY=
-	QJSC_PARAMS_STIP=
+	TJSC_PARAMS_STIP=
 endif
 
 all: $(TJS)
 
-$(BUILD_DIR):
+$(BUILD_DIR)/CMakeCache.txt:
 	cmake -B $(BUILD_DIR) -DCMAKE_BUILD_TYPE=$(BUILDTYPE)
 
-$(TJS): $(BUILD_DIR)
+$(TJS): $(BUILD_DIR)/CMakeCache.txt
 	cmake --build $(BUILD_DIR) -j $(JOBS)
 
-$(QJSC): $(BUILD_DIR)
+$(TJSC): $(BUILD_DIR)/CMakeCache.txt
 	cmake --build $(BUILD_DIR) --target tjsc -j $(JOBS)
 
 src/bundles/js/core/polyfills.js: src/js/polyfills/*.js
@@ -45,10 +45,10 @@ src/bundles/js/core/polyfills.js: src/js/polyfills/*.js
 		$(ESBUILD_PARAMS_MINIFY) \
 		$(ESBUILD_PARAMS_COMMON)
 
-src/bundles/c/core/polyfills.c: $(QJSC) src/bundles/js/core/polyfills.js
+src/bundles/c/core/polyfills.c: $(TJSC) src/bundles/js/core/polyfills.js
 	@mkdir -p $(basename $(dir $@))
-	$(QJSC) -m \
-		$(QJSC_PARAMS_STIP) \
+	$(TJSC) -m \
+		$(TJSC_PARAMS_STIP) \
 		-o $@ \
 		-n "polyfills.js" \
 		-p tjs__ \
@@ -62,10 +62,10 @@ src/bundles/js/core/core.js: src/js/core/*.js
 		$(ESBUILD_PARAMS_MINIFY) \
 		$(ESBUILD_PARAMS_COMMON)
 
-src/bundles/c/core/core.c: $(QJSC) src/bundles/js/core/core.js
+src/bundles/c/core/core.c: $(TJSC) src/bundles/js/core/core.js
 	@mkdir -p $(basename $(dir $@))
-	$(QJSC) -m \
-		$(QJSC_PARAMS_STIP) \
+	$(TJSC) -m \
+		$(TJSC_PARAMS_STIP) \
 		-o $@ \
 		-n "core.js" \
 		-p tjs__ \
@@ -80,10 +80,10 @@ src/bundles/js/core/run-main.js: src/js/run-main/*.js
 		$(ESBUILD_PARAMS_MINIFY) \
 		$(ESBUILD_PARAMS_COMMON)
 
-src/bundles/c/core/run-main.c: $(QJSC) src/bundles/js/core/run-main.js
+src/bundles/c/core/run-main.c: $(TJSC) src/bundles/js/core/run-main.js
 	@mkdir -p $(basename $(dir $@))
-	$(QJSC) -m \
-		$(QJSC_PARAMS_STIP) \
+	$(TJSC) -m \
+		$(TJSC_PARAMS_STIP) \
 		-o $@ \
 		-n "run-main.js" \
 		-p tjs__ \
@@ -99,19 +99,19 @@ src/bundles/js/core/run-repl.js: src/js/run-repl/*.js
 		$(ESBUILD_PARAMS_MINIFY) \
 		$(ESBUILD_PARAMS_COMMON)
 
-src/bundles/c/core/run-repl.c: $(QJSC) src/bundles/js/core/run-repl.js
+src/bundles/c/core/run-repl.c: $(TJSC) src/bundles/js/core/run-repl.js
 	@mkdir -p $(basename $(dir $@))
-	$(QJSC) -m \
-		$(QJSC_PARAMS_STIP) \
+	$(TJSC) -m \
+		$(TJSC_PARAMS_STIP) \
 		-o $@ \
 		-n "run-repl.js" \
 		-p tjs__ \
 		src/bundles/js/core/run-repl.js
 
-src/bundles/c/core/worker-bootstrap.c: $(QJSC) src/js/worker/worker-bootstrap.js
+src/bundles/c/core/worker-bootstrap.c: $(TJSC) src/js/worker/worker-bootstrap.js
 	@mkdir -p $(basename $(dir $@))
-	$(QJSC) \
-		$(QJSC_PARAMS_STIP) \
+	$(TJSC) \
+		$(TJSC_PARAMS_STIP) \
 		-o $@ \
 		-n "worker-bootstrap.js" \
 		-p tjs__ \
@@ -119,10 +119,10 @@ src/bundles/c/core/worker-bootstrap.c: $(QJSC) src/js/worker/worker-bootstrap.js
 
 core: src/bundles/c/core/polyfills.c src/bundles/c/core/core.c src/bundles/c/core/run-main.c src/bundles/c/core/run-repl.c src/bundles/c/core/worker-bootstrap.c
 
-src/bundles/c/stdlib/%.c: $(QJSC) src/bundles/js/stdlib/%.js
+src/bundles/c/stdlib/%.c: $(TJSC) src/bundles/js/stdlib/%.js
 	@mkdir -p $(basename $(dir $@))
-	$(QJSC) -m \
-		$(QJSC_PARAMS_STIP) \
+	$(TJSC) -m \
+		$(TJSC_PARAMS_STIP) \
 		-o $@ \
 		-n "tjs:$(basename $(notdir $@))" \
 		-p tjs__ \
@@ -137,10 +137,10 @@ src/bundles/js/stdlib/%.js: src/js/stdlib/*.js src/js/stdlib/ffi/*.js
 		$(ESBUILD_PARAMS_MINIFY) \
 		$(ESBUILD_PARAMS_COMMON)
 
-src/bundles/c/stdlib/%.c: $(QJSC) src/bundles/js/stdlib/%.js
+src/bundles/c/stdlib/%.c: $(TJSC) src/bundles/js/stdlib/%.js
 	@mkdir -p $(basename $(dir $@))
-	$(QJSC) -m \
-		$(QJSC_PARAMS_STIP) \
+	$(TJSC) -m \
+		$(TJSC_PARAMS_STIP) \
 		-o $@ \
 		-n "tjs:$(basename $(notdir $@))" \
 		-p tjs__ \
@@ -148,7 +148,7 @@ src/bundles/c/stdlib/%.c: $(QJSC) src/bundles/js/stdlib/%.js
 
 stdlib: $(addprefix src/bundles/c/stdlib/, $(patsubst %.js, %.c, $(notdir $(STDLIB_MODULES))))
 
-js: core stdlib
+js: $(TJSC) core stdlib
 
 install: $(TJS)
 	cmake --build $(BUILD_DIR) --target install
@@ -166,6 +166,9 @@ distclean:
 format:
 	clang-format -i src/*.{c,h}
 
+lint:
+	npm run lint
+
 test:
 	./$(BUILD_DIR)/tjs test tests/
 
@@ -174,4 +177,4 @@ test-advanced:
 	./$(BUILD_DIR)/tjs --stack-size 10485760 test tests/advanced/
 
 .PRECIOUS: src/bundles/js/core/%.js src/bundles/js/stdlib/%.js
-.PHONY: all js debug install clean distclean format test test-advanced core stdlib $(TJS)
+.PHONY: all js debug install clean distclean format lint test test-advanced core stdlib


### PR DESCRIPTION
- The `js` target now depends on TJSC
- Add target for CMake cache file, so a stale build file will trigger a
  rebuild
- Add lint target
