### PR TITLE
text-coding,ws: use tjs_dbuf_init helper

### DIFF
--- a/src/text-coding.c
+++ b/src/text-coding.c
@@ -251,7 +251,7 @@ static JSValue tjs_utf8_decoder_decode(JSContext *ctx, JSValueConst this_val, in
     }
 
     DynBuf s;
-    dbuf_init2(&s, ctx, (DynBufReallocFunc *) js_realloc);
+    tjs_dbuf_init(ctx, &s);
     if (dbuf_claim(&s, bufsz) < 0) {
         return JS_ThrowOutOfMemory(ctx);
     }

--- a/src/ws.c
+++ b/src/ws.c
@@ -285,7 +285,7 @@ static JSValue tjs_ws_constructor(JSContext *ctx, JSValue new_target, int argc, 
         w->callbacks[i] = JS_UNDEFINED;
     }
     w->this_val = JS_UNDEFINED;
-    dbuf_init(&w->recv_buf);
+    tjs_dbuf_init(ctx, &w->recv_buf);
     init_list_head(&w->pending_writes);
 
     const char *url = JS_ToCString(ctx, argv[0]);


### PR DESCRIPTION
It uses our custom allocator, so let's make sure not to miss that.
