### PR TITLE
build: use esnext as the esbuild target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ TJS=$(BUILD_DIR)/tjs
 TJSC=$(BUILD_DIR)/tjsc
 STDLIB_MODULES=$(wildcard src/js/stdlib/*.js)
 ESBUILD?=npx esbuild
-ESBUILD_PARAMS_COMMON=--target=es2023 --platform=neutral --format=esm --main-fields=main,module
+ESBUILD_PARAMS_COMMON=--target=esnext --platform=neutral --format=esm --main-fields=main,module
 ESBUILD_PARAMS_MINIFY=--minify --keep-names
 TJSC_PARAMS_STIP=-s
 JS_NO_STRIP?=0

--- a/tests/advanced/esbuild.config.js
+++ b/tests/advanced/esbuild.config.js
@@ -13,7 +13,7 @@ for (const mod of modules) {
         outfile: path.join(__dirname, mod.out),
         format: 'esm',
         platform: 'neutral',
-        target: 'es2023',
+        target: 'esnext',
         minify: false,
     });
 }


### PR DESCRIPTION
QuickJS-NG has supported features beyond 2023 for a while now.
