### PR TITLE
[docs] Update code-bundling.md

### DIFF
--- a/website/docs/guides/code-bundling.md
+++ b/website/docs/guides/code-bundling.md
@@ -44,6 +44,14 @@ tjs bundle --minify my-app/index.ts bundle.js
 
 This is especially useful when creating [standalone executables](standalone-executables.md), as the bundled code is embedded in the resulting binary.
 
+### Other esbuild options
+
+Any other cli option of esbuild is also available in `tjs bundle`:
+
+```bash
+tjs bundle --minify --define:DEBUG=true --drop:debugger my-app/index.ts
+```
+
 ### How it works
 
 The first time you run `tjs bundle`, the esbuild binary is downloaded from the npm registry and cached in `~/.tjs/esbuild/<version>/`. Subsequent runs reuse the cached binary. The download requires no system tools since it uses the built-in `fetch` API and `DecompressionStream` to stream the tarball directly to disk.
@@ -97,20 +105,3 @@ Error: something went wrong
 ```
 
 Both inline source maps (`data:` URLs) and external `.map` files are supported.
-
-## Using esbuild directly
-
-If you need more control over the bundling process, you can invoke esbuild directly:
-
-```bash
-npx esbuild my-app/index.ts \
-    --bundle \
-    --outfile=bundle.js \
-    --external:tjs:* \
-    --target=esnext \
-    --platform=neutral \
-    --format=esm \
-    --main-fields=main,module
-```
-
-There are other interesting options available, check the [API documentation](https://esbuild.github.io/api/).

--- a/website/docs/guides/code-bundling.md
+++ b/website/docs/guides/code-bundling.md
@@ -46,11 +46,13 @@ This is especially useful when creating [standalone executables](standalone-exec
 
 ### Other esbuild options
 
-Any other cli option of esbuild is also available in `tjs bundle`:
+Any other cli option of esbuild is also available via `tjs bundle`:
 
 ```bash
 tjs bundle --minify --define:DEBUG=true --drop:debugger my-app/index.ts
 ```
+
+There are other interesting options available, check the [API documentation](https://esbuild.github.io/api/).
 
 ### How it works
 
@@ -105,3 +107,18 @@ Error: something went wrong
 ```
 
 Both inline source maps (`data:` URLs) and external `.map` files are supported.
+
+## Using esbuild directly
+
+If you want to use esbuild directly, that's possible:
+
+```bash
+npx esbuild my-app/index.ts \
+    --bundle \
+    --outfile=bundle.js \
+    --external:tjs:* \
+    --target=esnext \
+    --platform=neutral \
+    --format=esm \
+    --main-fields=main,module
+```


### PR DESCRIPTION
- Added `Other esbuild options` section.
- Removed `use esbuild directly` as it seems that `tjs bundle` covers all possible CLI cases.

while developing [txiki-utils](https://codeberg.org/houd1ni/txiki-utils) I have used esbuild directly, but as @saghul [noticed](https://github.com/saghul/txiki.js/discussions/922#discussioncomment-16928698), it could be done via [tjs bundle](https://txikijs.org/docs/guides/code-bundling). But until I had a look at [the sources](https://github.com/saghul/txiki.js/blob/f47617eb37830941a5a70ee572ce034d85bf7d8a/src/js/run-main/bundle.js#L150), I could not notice that it is possible to pass esbuild CLI parameters in `tjs bundle`.

Also while I was editing the docs to add the section, I finally got that [the very last one](https://txikijs.org/docs/guides/code-bundling#using-esbuild-directly) with its `There are other interesting options available` is exactly about that, so I've decided to remove it as it seems that `tjs bundle` already covers all possible CLI cases indeed. But I would not argue if it would stay there (: