### PR TITLE
wasm: detach stale memory.buffer ArrayBuffer on grow

### DIFF
--- a/src/wasm.c
+++ b/src/wasm.c
@@ -120,11 +120,19 @@ typedef struct {
     JSValue *externrefs;
     uint32_t externref_count;
     uint32_t externref_capacity;
+    /* Cached ArrayBuffer aliasing WAMR linear memory. Detached and replaced
+     * whenever WAMR moves or resizes the underlying memory. */
+    JSValue memory_buffer;
+    void *memory_buffer_data;
+    size_t memory_buffer_size;
 } TJSWasmInstance;
 
 static void tjs_wasm_instance_finalizer(JSRuntime *rt, JSValue val) {
     TJSWasmInstance *i = JS_GetOpaque(val, tjs_wasm_instance_class_id);
     if (i) {
+        if (!JS_IsUndefined(i->memory_buffer)) {
+            JS_FreeValueRT(rt, i->memory_buffer);
+        }
         if (i->exec_env) {
             wasm_runtime_destroy_exec_env(i->exec_env);
         }
@@ -171,6 +179,9 @@ static void tjs_wasm_instance_mark(JSRuntime *rt, JSValue val, JS_MarkFunc *mark
         }
         for (uint32_t j = 0; j < i->externref_count; j++) {
             JS_MarkValue(rt, i->externrefs[j], mark_func);
+        }
+        if (!JS_IsUndefined(i->memory_buffer)) {
+            JS_MarkValue(rt, i->memory_buffer, mark_func);
         }
     }
 }
@@ -219,6 +230,8 @@ static JSValue tjs_new_wasm_instance(JSContext *ctx) {
         return JS_EXCEPTION;
     }
 
+    i->memory_buffer = JS_UNDEFINED;
+
     JS_SetOpaque(obj, i);
     return obj;
 }
@@ -254,6 +267,44 @@ static JSValue tjs__wasm_val_to_js(JSContext *ctx, const wasm_val_t *val) {
             return JS_NewFloat64(ctx, val->of.f64);
         default:
             return JS_UNDEFINED;
+    }
+}
+
+/* Detach the cached memory.buffer ArrayBuffer (if any) and clear the cache. */
+static void tjs__wasm_drop_memory_buffer(JSContext *ctx, TJSWasmInstance *i) {
+    if (JS_IsUndefined(i->memory_buffer)) {
+        return;
+    }
+
+    JS_DetachArrayBuffer(ctx, i->memory_buffer);
+    JS_FreeValue(ctx, i->memory_buffer);
+    i->memory_buffer = JS_UNDEFINED;
+    i->memory_buffer_data = NULL;
+    i->memory_buffer_size = 0;
+}
+
+/* Drop the cached ArrayBuffer if WAMR linear memory has moved or resized
+ * since we handed it out. Must be called after any operation that could
+ * trigger growth — both the JS-side grow API and the WASM `memory.grow`
+ * instruction executed inside a wasm_runtime_call_wasm_a call. */
+static void tjs__wasm_drop_memory_buffer_if_changed(JSContext *ctx, TJSWasmInstance *i) {
+    if (JS_IsUndefined(i->memory_buffer)) {
+        return;
+    }
+
+    wasm_memory_inst_t mem = wasm_runtime_get_default_memory(i->module_inst);
+    if (!mem) {
+        tjs__wasm_drop_memory_buffer(ctx, i);
+        return;
+    }
+
+    void *base = wasm_memory_get_base_address(mem);
+    uint64_t page_count = wasm_memory_get_cur_page_count(mem);
+    uint64_t bytes_per_page = wasm_memory_get_bytes_per_page(mem);
+    size_t byte_length = (size_t) (page_count * bytes_per_page);
+
+    if (base != i->memory_buffer_data || byte_length != i->memory_buffer_size) {
+        tjs__wasm_drop_memory_buffer(ctx, i);
     }
 }
 
@@ -728,7 +779,13 @@ static JSValue tjs__call_wasm_func_inst(JSContext *ctx,
 
     wasm_val_t results[TJS__WASM_MAX_ARGS];
 
-    if (!wasm_runtime_call_wasm_a(inst->exec_env, func, result_count, results, param_count, params)) {
+    bool ok = wasm_runtime_call_wasm_a(inst->exec_env, func, result_count, results, param_count, params);
+    /* WASM code may have run `memory.grow` while we were inside the call,
+     * invalidating any ArrayBuffer we previously handed out. Detach now so
+     * stale views can no longer dereference moved-or-freed storage. */
+    tjs__wasm_drop_memory_buffer_if_changed(ctx, inst);
+
+    if (!ok) {
         /* If an imported JS function threw, re-throw the original JS exception */
         if (inst->has_pending_exception) {
             JSValue exc = inst->pending_exception;
@@ -1376,7 +1433,26 @@ static JSValue tjs_wasm_getmemorybuffer(JSContext *ctx, JSValue this_val, int ar
     uint64_t bytes_per_page = wasm_memory_get_bytes_per_page(mem);
     size_t byte_length = (size_t) (page_count * bytes_per_page);
 
-    return JS_NewArrayBuffer(ctx, (uint8_t *) base, byte_length, tjs__wasm_memory_free, NULL, false);
+    /* Reuse the cached ArrayBuffer while the underlying storage has not moved
+     * or resized — WebAssembly.Memory.prototype.buffer must return the same
+     * object across calls until a successful grow. */
+    if (!JS_IsUndefined(i->memory_buffer)) {
+        if (base == i->memory_buffer_data && byte_length == i->memory_buffer_size) {
+            return JS_DupValue(ctx, i->memory_buffer);
+        }
+        tjs__wasm_drop_memory_buffer(ctx, i);
+    }
+
+    JSValue buffer = JS_NewArrayBuffer(ctx, (uint8_t *) base, byte_length, tjs__wasm_memory_free, NULL, false);
+    if (JS_IsException(buffer)) {
+        return buffer;
+    }
+
+    i->memory_buffer = JS_DupValue(ctx, buffer);
+    i->memory_buffer_data = base;
+    i->memory_buffer_size = byte_length;
+
+    return buffer;
 }
 
 static JSValue tjs_wasm_growmemory(JSContext *ctx, JSValue this_val, int argc, JSValue *argv) {
@@ -1398,12 +1474,17 @@ static JSValue tjs_wasm_growmemory(JSContext *ctx, JSValue this_val, int argc, J
     uint64_t old_pages = wasm_memory_get_cur_page_count(mem);
 
     if (delta == 0) {
+        /* Per the JS API spec, a successful grow (including delta == 0)
+         * detaches the existing buffer. */
+        tjs__wasm_drop_memory_buffer(ctx, i);
         return JS_NewUint32(ctx, (uint32_t) old_pages);
     }
 
     if (!wasm_memory_enlarge(mem, delta)) {
         return JS_ThrowRangeError(ctx, "failed to grow memory");
     }
+
+    tjs__wasm_drop_memory_buffer(ctx, i);
 
     return JS_NewUint32(ctx, (uint32_t) old_pages);
 }

--- a/tests/test-wasm-memory-detach.js
+++ b/tests/test-wasm-memory-detach.js
@@ -1,0 +1,73 @@
+// Regression: a successful WebAssembly.Memory grow must detach the previously
+// handed-out ArrayBuffer so that prior TypedArray views can no longer alias
+// linear memory whose owner (WAMR) may have moved or unmapped it.
+
+import assert from 'tjs:assert';
+
+// Minimal module exporting a single Memory of 1 page.
+const wasmBytes = new Uint8Array([
+    0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    0x05, 0x04, 0x01, 0x01, 0x01, 0x0a,
+    0x07, 0x07, 0x01, 0x03, 0x6d, 0x65, 0x6d, 0x02, 0x00,
+]);
+
+// JS-side grow detaches the buffer.
+{
+    const mod = new WebAssembly.Module(wasmBytes);
+    const inst = new WebAssembly.Instance(mod, {});
+    const mem = inst.exports.mem;
+
+    const buf = mem.buffer;
+    const view = new Uint8Array(buf);
+
+    view[0] = 0x41;
+    view[65535] = 0x42;
+
+    mem.grow(8);
+
+    assert.eq(buf.byteLength, 0, 'old buffer is detached after grow');
+    assert.eq(view.byteLength, 0, 'stale view sees zero length');
+    assert.eq(view[0], undefined, 'stale view reads return undefined');
+    assert.eq(view[65535], undefined, 'stale view reads anywhere return undefined');
+
+    // Writes through the stale view must not reach the new linear memory or
+    // any unrelated mapping the OS may have placed at the old address.
+    view[0] = 0xcc;
+    const fresh = new Uint8Array(mem.buffer);
+    assert.eq(fresh[0], 0x41, 'write via stale view does not affect new memory');
+}
+
+// Two independent Memory instances must remain isolated, even after one of
+// them has been grown and its old buffer detached.
+{
+    const modA = new WebAssembly.Module(wasmBytes);
+    const modB = new WebAssembly.Module(wasmBytes);
+    const a = new WebAssembly.Instance(modA, {}).exports.mem;
+    const b = new WebAssembly.Instance(modB, {}).exports.mem;
+
+    const staleA = new Uint8Array(a.buffer);
+
+    staleA[0] = 0xaa;
+    a.grow(4);
+
+    const freshB = new Uint8Array(b.buffer);
+
+    freshB[0] = 0xbb;
+
+    // Writes through the detached view must not bleed into b's memory.
+    staleA[0] = 0xff;
+    assert.eq(freshB[0], 0xbb, 'detached buffer cannot alias another Memory instance');
+}
+
+// grow(0) is a successful no-op but still detaches the existing buffer.
+{
+    const mod = new WebAssembly.Module(wasmBytes);
+    const inst = new WebAssembly.Instance(mod, {});
+    const mem = inst.exports.mem;
+
+    const buf = mem.buffer;
+
+    assert.eq(mem.grow(0), 1, 'grow(0) returns current page count');
+    assert.eq(buf.byteLength, 0, 'grow(0) detaches the existing buffer');
+    assert.isNot(mem.buffer, buf, 'buffer getter returns a new object after grow(0)');
+}

--- a/tests/test-wasm-memory.js
+++ b/tests/test-wasm-memory.js
@@ -12,6 +12,7 @@ assert.ok(exports.memory instanceof WebAssembly.Memory, 'memory export is a Memo
 const buf = exports.memory.buffer;
 assert.ok(buf instanceof ArrayBuffer, 'buffer is an ArrayBuffer');
 assert.eq(buf.byteLength, 65536, 'initial size is 1 page');
+assert.is(exports.memory.buffer, buf, 'buffer getter returns the same object while no grow has occurred');
 
 // Write via WASM, read from JS.
 exports.store_i32(0, 42);
@@ -30,9 +31,15 @@ assert.eq(bytes[100], 0xff, 'byte access works');
 // Memory size query via WASM.
 assert.eq(exports.mem_size(), 1, 'WASM reports 1 page');
 
-// Grow from JS side.
+// Grow from JS side detaches any prior buffer (the underlying linear memory
+// may move; aliasing views must not keep dereferencing the old base).
+const staleView = new Uint8Array(buf);
 const oldPages = exports.memory.grow(2);
 assert.eq(oldPages, 1, 'grow returns old page count');
+assert.eq(buf.byteLength, 0, 'old buffer is detached after JS-side grow');
+assert.throws(() => new Uint8Array(buf), TypeError, 'detached buffer cannot be viewed');
+assert.eq(staleView.byteLength, 0, 'TypedArray over detached buffer has zero length');
+assert.eq(staleView[0], undefined, 'reads through stale view return undefined');
 assert.eq(exports.memory.buffer.byteLength, 3 * 65536, 'buffer grew to 3 pages');
 assert.eq(exports.mem_size(), 3, 'WASM sees grown memory');
 
@@ -41,9 +48,21 @@ const viewAfter = new DataView(exports.memory.buffer);
 assert.eq(viewAfter.getInt32(0, true), 42, 'data survives grow');
 
 // Grow from WASM side.
+const beforeWasmGrow = exports.memory.buffer;
+const staleViewWasm = new Uint8Array(beforeWasmGrow);
 const wasmOldPages = exports.mem_grow(1);
 assert.eq(wasmOldPages, 3, 'WASM grow returns old page count');
+assert.eq(beforeWasmGrow.byteLength, 0, 'old buffer is detached after WASM-side grow');
+assert.throws(() => new Uint8Array(beforeWasmGrow), TypeError, 'detached buffer cannot be viewed');
+assert.eq(staleViewWasm.byteLength, 0, 'TypedArray over WASM-detached buffer has zero length');
 assert.eq(exports.memory.buffer.byteLength, 4 * 65536, 'JS sees WASM-side grow');
+
+// grow(0) is a successful no-op but still detaches the existing buffer.
+const beforeZeroGrow = exports.memory.buffer;
+const zeroOld = exports.memory.grow(0);
+assert.eq(zeroOld, 4, 'grow(0) returns the current page count');
+assert.eq(beforeZeroGrow.byteLength, 0, 'grow(0) detaches the previous buffer');
+assert.eq(exports.memory.buffer.byteLength, 4 * 65536, 'memory size unchanged after grow(0)');
 
 // Standalone Memory.
 const mem = new WebAssembly.Memory({ initial: 2, maximum: 4 });


### PR DESCRIPTION
WAMR's wasm_memory_enlarge may relocate (or, on Linux, mremap with movement)
the linear memory backing a WebAssembly.Memory. The previously handed-out
ArrayBuffer kept its original data pointer and byteLength, letting JS reach
through stale TypedArray views into moved-or-unmapped storage — a memory
safety bug reachable from any JS that can run WebAssembly.

Cache the JSValue returned by getMemoryBuffer on the instance, then detach
and clear it whenever the base address or size changes:

- The JS-side Memory.prototype.grow path detaches unconditionally (a
  successful grow detaches the existing buffer per the JS API spec, even
  for delta == 0).
- The WASM `memory.grow` instruction is invisible to us until control
  returns, so wasm_runtime_call_wasm_a is followed by an opportunistic
  base/size check that detaches when the storage has moved.
- The cache is marked during GC and released in the finalizer so the
  ArrayBuffer's lifetime tracks the instance's.

After the fix the report's stale-read PoC no longer faults; views over the
detached buffer report zero length and writes through them no longer reach
the new mapping or alias an independent Memory instance.

Co-authored-by: Saúl Ibarra Corretgé <s@saghul.net>
