### PR TITLE
httpserver: free request state after each keep-alive response

### DIFF
--- a/src/httpserver.c
+++ b/src/httpserver.c
@@ -183,6 +183,23 @@ static void tjs_http_req_free(JSRuntime *rt, TJSHttpRequest *req) {
     js_free_rt(rt, req);
 }
 
+/*
+ * Detach a completed request from its wsi and free it.  Used once the
+ * response is fully transmitted: on a keep-alive connection lws may reuse
+ * the wsi for another transaction (a new req via LWS_CALLBACK_HTTP), and
+ * without this cleanup the previous req leaks until the connection closes.
+ */
+static void tjs_http_req_complete(TJSHttpServer *s, TJSHttpRequest *req) {
+    if (!req) {
+        return;
+    }
+    HASH_DEL(s->active_requests, req);
+    if (req->wsi && lws_wsi_user(req->wsi) == req) {
+        lws_set_wsi_user(req->wsi, NULL);
+    }
+    tjs_http_req_free(JS_GetRuntime(s->ctx), req);
+}
+
 static void tjs_wsconn_finalizer(JSRuntime *rt, JSValue val) {
     TJSWsConnection *ws = JS_GetOpaque(val, tjs_wsconn_class_id);
     if (ws) {
@@ -1015,10 +1032,12 @@ static int tjs_http_callback(struct lws *wsi, enum lws_callback_reasons reason, 
                 }
 
                 if (is_final) {
-                    if (lws_http_transaction_completed(wsi)) {
-                        return -1;
-                    }
-                } else if (!list_empty(&req->pending_writes)) {
+                    int must_close = lws_http_transaction_completed(wsi);
+                    tjs_http_req_complete(s, req);
+                    return must_close ? -1 : 0;
+                }
+
+                if (!list_empty(&req->pending_writes)) {
                     lws_callback_on_writable(wsi);
                 }
 
@@ -1051,13 +1070,12 @@ static int tjs_http_callback(struct lws *wsi, enum lws_callback_reasons reason, 
             req->response_offset += n;
 
             if (req->response_offset >= total_payload) {
-                if (lws_http_transaction_completed(wsi)) {
-                    return -1;
-                }
-            } else {
-                lws_callback_on_writable(wsi);
+                int must_close = lws_http_transaction_completed(wsi);
+                tjs_http_req_complete(s, req);
+                return must_close ? -1 : 0;
             }
 
+            lws_callback_on_writable(wsi);
             return 0;
         }
 
@@ -1595,10 +1613,13 @@ static JSValue tjs_httpserver_send_response(JSContext *ctx, JSValue this_val, in
     if (body_len > 0) {
         lws_callback_on_writable(req->wsi);
     } else {
-        /* No body, complete the transaction. */
-        if (lws_http_transaction_completed(req->wsi)) {
-            return JS_UNDEFINED;
-        }
+        /* No body, complete the transaction now and release the request so
+         * a subsequent keep-alive transaction on this wsi doesn't accumulate
+         * the previous request's state.  The return value indicates whether
+         * lws will close the connection; either way we drop our state here
+         * and let lws handle the wsi lifecycle. */
+        (void) lws_http_transaction_completed(req->wsi);
+        tjs_http_req_complete(s, req);
     }
 
     return JS_UNDEFINED;

--- a/tests/test-httpserver-keepalive.js
+++ b/tests/test-httpserver-keepalive.js
@@ -1,0 +1,180 @@
+import assert from 'tjs:assert';
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function delay(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+// Read until we've collected one complete Content-Length-delimited HTTP/1.1
+// response on the wire, returning that response and any leftover bytes that
+// belong to the next response.
+async function readContentLengthResponse(reader, initial) {
+    let buf = initial;
+
+    while (true) {
+        const idx = buf.indexOf('\r\n\r\n');
+
+        if (idx >= 0) {
+            const head = buf.slice(0, idx);
+            const m = head.match(/\r\nContent-Length:\s*(\d+)/i);
+
+            if (!m) {
+                throw new Error(`missing Content-Length in response: ${head}`);
+            }
+
+            const bodyLen = parseInt(m[1], 10);
+            const total = idx + 4 + bodyLen;
+
+            if (buf.length >= total) {
+                return { response: buf.slice(0, total), rest: buf.slice(total) };
+            }
+        }
+
+        const read = reader.read();
+        const timeout = delay(2000).then(() => ({ done: true, timeout: true }));
+        const { value, done, timeout: timedOut } = await Promise.race([ read, timeout ]);
+
+        if (timedOut) {
+            throw new Error(`timed out (have ${buf.length} bytes)`);
+        }
+
+        if (done) {
+            throw new Error(`connection closed mid-response (have ${buf.length} bytes)`);
+        }
+
+        buf += decoder.decode(value, { stream: true });
+    }
+}
+
+// Buffered responses on a single keep-alive connection.  Regression test
+// for https://github.com/saghul/txiki.js/issues/924 — non-streaming
+// responses were retaining their response_data buffer for the entire
+// connection lifetime instead of being freed once the response completed.
+async function testBufferedKeepAlive() {
+    let count = 0;
+    const server = tjs.serve({
+        port: 0,
+        listenIp: '127.0.0.1',
+        fetch: () => {
+            count++;
+            // Use a non-trivial body so a reintroduction of the leak would
+            // be obvious to a heap profiler — every request would otherwise
+            // retain 64 KiB until the connection closed.
+            const body = new Uint8Array(64 * 1024).fill(0x41 + (count % 26));
+
+            return new Response(body, { headers: { 'content-type': 'application/octet-stream' } });
+        },
+    });
+
+    const con = await tjs.connect('tcp', '127.0.0.1', server.port);
+    const { readable, writable } = await con.opened;
+    const writer = writable.getWriter();
+    const reader = readable.getReader();
+
+    const N = 20;
+    let leftover = '';
+
+    for (let i = 0; i < N; i++) {
+        const last = i === N - 1;
+        const req = `GET /${i} HTTP/1.1\r\nHost: 127.0.0.1\r\n` +
+            (last ? 'Connection: close\r\n' : '') + '\r\n';
+
+        await writer.write(encoder.encode(req));
+
+        const { response, rest } = await readContentLengthResponse(reader, leftover);
+
+        leftover = rest;
+
+        assert.ok(response.startsWith('HTTP/1.1 200'), `request ${i} got 200`);
+        assert.ok(/\r\nContent-Length:\s*65536\r\n/i.test(response),
+            `request ${i} has 64 KiB body`);
+    }
+
+    assert.eq(count, N, `server handled ${N} requests`);
+
+    try {
+        await writer.close();
+    } catch {}
+
+    try {
+        con.close();
+    } catch {}
+
+    server.close();
+}
+
+// Empty-body buffered responses on a keep-alive connection.  The no-body
+// code path in sendResponse is separate from the body path and also needs
+// to release the request promptly.
+async function testEmptyBodyKeepAlive() {
+    let count = 0;
+    const server = tjs.serve({
+        port: 0,
+        listenIp: '127.0.0.1',
+        fetch: () => {
+            count++;
+
+            return new Response(null, { status: 204 });
+        },
+    });
+
+    const con = await tjs.connect('tcp', '127.0.0.1', server.port);
+    const { readable, writable } = await con.opened;
+    const writer = writable.getWriter();
+    const reader = readable.getReader();
+
+    const N = 10;
+    let buf = '';
+
+    for (let i = 0; i < N; i++) {
+        const last = i === N - 1;
+        const req = `GET /${i} HTTP/1.1\r\nHost: 127.0.0.1\r\n` +
+            (last ? 'Connection: close\r\n' : '') + '\r\n';
+
+        await writer.write(encoder.encode(req));
+
+        // 204 responses must have no body; just read until headers terminate.
+        while (true) {
+            const idx = buf.indexOf('\r\n\r\n');
+
+            if (idx >= 0) {
+                const head = buf.slice(0, idx);
+
+                assert.ok(head.startsWith('HTTP/1.1 204'), `request ${i} got 204`);
+                buf = buf.slice(idx + 4);
+                break;
+            }
+
+            const read = reader.read();
+            const timeout = delay(2000).then(() => ({ done: true, timeout: true }));
+            const { value, done, timeout: timedOut } = await Promise.race([ read, timeout ]);
+
+            if (timedOut) {
+                throw new Error(`request ${i}: timed out`);
+            }
+
+            if (done) {
+                throw new Error(`request ${i}: connection closed`);
+            }
+
+            buf += decoder.decode(value, { stream: true });
+        }
+    }
+
+    assert.eq(count, N, `server handled ${N} requests`);
+
+    try {
+        await writer.close();
+    } catch {}
+
+    try {
+        con.close();
+    } catch {}
+
+    server.close();
+}
+
+await testBufferedKeepAlive();
+await testEmptyBodyKeepAlive();


### PR DESCRIPTION
The TJSHttpRequest was only freed in LWS_CALLBACK_CLOSED_HTTP, so on a
keep-alive connection each new HTTP transaction allocated a fresh req
and overwrote the wsi user pointer, leaving prior reqs (and their
response_data buffers) reachable only via active_requests until the
connection finally closed. Long-lived clients accumulated the full
response body of every request.

Release the request as soon as lws_http_transaction_completed runs in
the buffered and streaming write paths, and in the no-body
sendResponse path. CLOSED_HTTP still handles connection-close cleanup
when no transaction was outstanding.

Fixes #924.
