### PR TITLE
change return type of `tjs.exit` to never

### DIFF
--- a/types/src/txikijs.d.ts
+++ b/types/src/txikijs.d.ts
@@ -199,7 +199,7 @@ declare global {
         * @category Process
         * @param code Program exit code.
         */
-        function exit(code: number): void;
+        function exit(code: number): never;
 
         /**
         * Changes the current working directory.


### PR DESCRIPTION
Change the TypeScript declaration of `tjs.exit()` from `void` to `never`.

`tjs.exit()` terminates the process and does not return to the caller, so `never` better reflects its control-flow behavior.

This fixes cases where TypeScript incorrectly thinks execution may continue after `tjs.exit()`:

For example, with current version of `@txikijs/types` (v26.5.0)
```ts
let content;

if (tjs.args[2]) {
    const file_path = tjs.args[2];
    content = await read_text_file(file_path);
} else  {
    console.error(`Usage: tjs run main.js <path-to-file>`);
    tjs.exit(1);
}

print(content);  // typescript analyzer complains `content` may be `undefined`
````

With returning type `never`, TypeScript correctly understands that the "else" block cannot complete normally, so `content` is known to be assigned after the if-else blocks. 
