### PR TITLE
docs: add installation instructions for Homebrew, WinGet, and Scoop

### DIFF
--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -13,6 +13,26 @@ It's built on the shoulders of giants: it uses [QuickJS-ng](https://github.com/q
 
 ## Installation
 
+### [Homebrew](https://brew.sh/) (macOS and Linux)
+
+```bash
+brew install saghul/tap/txikijs
+```
+
+### [WinGet](https://learn.microsoft.com/windows/package-manager/) (Windows)
+
+```powershell
+winget install Saghul.TxikiJS
+```
+
+### [Scoop](https://scoop.sh/) (Windows)
+
+```powershell
+scoop install txikijs
+```
+
+### Prebuilt binaries
+
 Prebuilt binaries are available for macOS and Windows from the [GitHub Releases](https://github.com/saghul/txiki.js/releases) page:
 
 | Platform | Architecture |
@@ -21,6 +41,8 @@ Prebuilt binaries are available for macOS and Windows from the [GitHub Releases]
 | Windows | x86_64 |
 
 Download the zip for your platform, extract it, and add the `tjs` binary to your `PATH`.
+
+### Build from source
 
 On Linux (and other Unixes), you'll need to [build from source](building.md).
 


### PR DESCRIPTION
Related to #915. Not closing it yet since there is still an ongoing discussion around `mise`.

This PR adds installation instructions for Homebrew, WinGet, and Scoop.

For Homebrew, this uses a custom tap, [bangseongbeom/tap](https://github.com/bangseongbeom/homebrew-tap), instead of the official [homebrew-core](https://github.com/Homebrew/homebrew-core), because the formula depends on too many custom parts to be a good fit for the offical homebrew-core. See https://github.com/Homebrew/homebrew-core/pull/272588#issuecomment-4080826336 for context.

From the perspective of someone installing the package, I think saghul/tap, maintained by saghul as the owner of this repository, would be more trustworthy than installing from my personal tap. Please let me know if you would like to discuss taking over or maintaining the custom tap.