### PR TITLE
lws: support authenticated proxy URLs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,11 +320,14 @@ set(LWS_WITH_LWSAC OFF CACHE BOOL "" FORCE)
 set(LWS_WITH_CONMON OFF CACHE BOOL "" FORCE)
 set(LWS_WITH_WOL OFF CACHE BOOL "" FORCE)
 set(LWS_WITH_STUB OFF CACHE BOOL "" FORCE)
-set(LWS_WITH_HTTP_BASIC_AUTH OFF CACHE BOOL "" FORCE)
+# BASIC_AUTH must stay ON: it gates the client-side "Proxy-Authorization:
+# basic" header (connect4.c), without which authenticated proxy URLs
+# (http_proxy=http://user:pass@host:port) route through the proxy but never
+# send credentials.
+set(LWS_WITH_HTTP_BASIC_AUTH ON CACHE BOOL "" FORCE)
 set(LWS_WITH_HTTP_DIGEST_AUTH OFF CACHE BOOL "" FORCE)
 # GENCRYPTO must stay ON: lws compiles tls/lws-gencrypto-common.c (HKDF)
-# unconditionally, which needs the genhmac API. Unused objects are not
-# linked into the final binary anyway.
+# unconditionally, which needs the genhmac API.
 set(LWS_WITH_GENCRYPTO ON CACHE BOOL "" FORCE)
 # Note: LWS_WITH_HTTP_UNCOMMON_HEADERS must stay ON: it selects the full
 # pre-generated header lexer table; without it headers like

--- a/src/lws-utils.c
+++ b/src/lws-utils.c
@@ -195,15 +195,29 @@ static void tjs__set_ca_info(TJSRuntime *qrt, struct lws_context_creation_info *
 /*
  * Per-scheme proxy configuration.
  *
- * Work around a bug in lws_set_proxy() where the proxy address is not
- * null-terminated after parsing the port, causing crashes in async DNS.
- * We parse the env vars ourselves and pass the host and port separately
- * via lws_context_creation_info.  When http_proxy_address is set in the
- * info struct, lws skips its own getenv("http_proxy") code path.
+ * We parse the proxy env vars ourselves and pass the host and port to lws as
+ * separate fields (http_proxy_address + http_proxy_port) via
+ * lws_context_creation_info, rather than letting lws read the env var itself.
+ * Two lws limitations make this necessary:
+ *
+ *   1. lws_set_proxy() does not truncate the address at the ':' before the
+ *      port (the historical "*p = '\0'" was dropped upstream), so handing it a
+ *      "host:port" string leaves the ":port" suffix in http_proxy_address,
+ *      which is then used verbatim as the DNS peer address and breaks
+ *      resolution.  Passing the port separately keeps the address clean.
+ *
+ *   2. lws_parse_uri_create() does not understand userinfo: its host scan
+ *      stops at the first ':', so "user:pass@host" would parse as host="user".
+ *      We therefore split any "userinfo@" prefix off ourselves before parsing,
+ *      and hand it back to lws_set_proxy() (which base64-encodes it for the
+ *      Proxy-Authorization header) as part of http_proxy_address.
+ *
+ * Setting http_proxy_address in the info struct also makes lws skip its own
+ * getenv("http_proxy") code path.
  */
 typedef struct {
-    char auth_address[512]; /* "user:pass@host" or "host" (for lws_set_proxy) */
-    char hostname[256];     /* just host (for no_proxy matching) */
+    char auth_address[512]; /* "userinfo@host" or "host", never a port (for lws_set_proxy) */
+    char hostname[256];     /* just host, no userinfo/port (for no_proxy matching) */
     unsigned int port;
 } TJSProxyConfig;
 
@@ -223,25 +237,65 @@ static bool tjs__parse_proxy_url(const char *env_name1, const char *env_name2, T
         return false;
     }
 
-    lws_parse_uri_t *uri = lws_parse_uri_create(buf);
+    /*
+     * Split off any "userinfo@" prefix before handing the URL to
+     * lws_parse_uri_create() (see the note above on why it can't parse
+     * userinfo itself).  userinfo ends at the last '@' within the authority.
+     */
+    const char *authority = buf;
+    const char *scheme_sep = strstr(buf, "://");
+    if (scheme_sep) {
+        authority = scheme_sep + 3;
+    }
+
+    const char *path = authority + strcspn(authority, "/?");
+    const char *userinfo_end = NULL;
+    for (const char *p = authority; p < path; p++) {
+        if (*p == '@') {
+            userinfo_end = p;
+        }
+    }
+
+    char userinfo[256] = { 0 };
+    char clean[512];
+
+    if (userinfo_end) {
+        size_t ulen = (size_t) (userinfo_end - authority);
+        lws_strncpy(userinfo, authority, ulen + 1 < sizeof(userinfo) ? ulen + 1 : sizeof(userinfo));
+
+        /* Rebuild the URL without the userinfo: scheme + host[:port][/...]. */
+        size_t prefix = (size_t) (authority - buf);
+        if (prefix >= sizeof(clean)) {
+            return false;
+        }
+        memcpy(clean, buf, prefix);
+        lws_strncpy(clean + prefix, userinfo_end + 1, sizeof(clean) - prefix);
+    } else {
+        lws_strncpy(clean, buf, sizeof(clean));
+    }
+
+    lws_parse_uri_t *uri = lws_parse_uri_create(clean);
     if (!uri) {
         return false;
     }
 
-    lws_strncpy(out->auth_address, uri->host, sizeof(out->auth_address));
+    /* hostname (no userinfo, no port) is used for no_proxy matching. */
+    lws_strncpy(out->hostname, uri->host, sizeof(out->hostname));
     out->port = uri->port;
 
-    /* If the host contains '@', auth is present — extract just the hostname. */
-    const char *at = strchr(uri->host, '@');
-    if (at) {
-        lws_strncpy(out->hostname, at + 1, sizeof(out->hostname));
+    /*
+     * auth_address is handed to lws_set_proxy() via http_proxy_address: the
+     * host plus any userinfo (for Proxy-Authorization), but never the port.
+     */
+    if (userinfo[0]) {
+        lws_snprintf(out->auth_address, sizeof(out->auth_address), "%s@%s", userinfo, uri->host);
     } else {
-        lws_strncpy(out->hostname, uri->host, sizeof(out->hostname));
+        lws_strncpy(out->auth_address, uri->host, sizeof(out->auth_address));
     }
 
     lws_parse_uri_destroy(&uri);
 
-    return out->port > 0 && out->auth_address[0];
+    return out->port > 0 && out->hostname[0];
 }
 
 static void tjs__parse_no_proxy(TJSRuntime *qrt) {

--- a/tests/helpers/connect-proxy-auth.js
+++ b/tests/helpers/connect-proxy-auth.js
@@ -1,0 +1,125 @@
+// HTTP CONNECT proxy that REQUIRES Basic proxy authentication, for testing
+// authenticated proxy URLs (http_proxy=http://user:pass@host:port).
+//
+// - Verifies the Proxy-Authorization header carries base64("user:pass") from
+//   PROXY_AUTH; on a missing/wrong credential it replies 407 and closes.
+// - On success it tunnels to 127.0.0.1:BACKEND_PORT, IGNORING the CONNECT
+//   target. The test points the request at a dead port, so it can only
+//   succeed if it actually went through this proxy (proving the authenticated
+//   proxy was used, not silently dropped).
+
+const decoder = new TextDecoder();
+const encoder = new TextEncoder();
+
+const expectedToken = btoa(tjs.env.PROXY_AUTH);   // base64("user:pass")
+const backendPort = parseInt(tjs.env.BACKEND_PORT);
+
+const server = await tjs.listen('tcp', '127.0.0.1', 0);
+const { readable, localPort } = await server.opened;
+
+// Signal the port to the parent on stdout.
+console.log(String(localPort));
+
+const acceptReader = readable.getReader();
+
+async function handleClient(conn) {
+    const { readable: cr, writable: cw } = await conn.opened;
+    const reader = cr.getReader();
+
+    // Read the CONNECT request line + headers.
+    let buf = '';
+
+    while (true) {
+        const { value, done } = await reader.read();
+
+        if (done) {
+            return;
+        }
+
+        buf += decoder.decode(value);
+
+        if (buf.includes('\r\n\r\n')) {
+            break;
+        }
+    }
+
+    const writer = cw.getWriter();
+
+    // Verify the Proxy-Authorization header (scheme is case-insensitive; lws
+    // emits a lowercase "basic"). Compare only the base64 token.
+    const m = buf.match(/Proxy-Authorization:\s*\S+\s+(\S+)\r\n/i);
+
+    if (!m || m[1].trim() !== expectedToken) {
+        await writer.write(encoder.encode('HTTP/1.1 407 Proxy Authentication Required\r\n\r\n'));
+        writer.releaseLock();
+        conn.close();
+
+        return;
+    }
+
+    // Auth OK — tunnel to the real backend (ignoring the CONNECT target).
+    let target;
+
+    try {
+        target = await tjs.connect('tcp', '127.0.0.1', backendPort);
+        await target.opened;
+    } catch {
+        await writer.write(encoder.encode('HTTP/1.1 502 Bad Gateway\r\n\r\n'));
+        writer.releaseLock();
+        conn.close();
+
+        return;
+    }
+
+    const { readable: tr, writable: tw } = await target.opened;
+
+    await writer.write(encoder.encode('HTTP/1.1 200 Connection Established\r\n\r\n'));
+    writer.releaseLock();
+    reader.releaseLock();
+
+    // Tunnel data in both directions.
+    async function pipe(from, to) {
+        const r = from.getReader();
+        const w = to.getWriter();
+
+        try {
+            while (true) {
+                const { value, done } = await r.read();
+
+                if (done) {
+                    break;
+                }
+
+                await w.write(value);
+            }
+        } catch {
+            // Connection closed.
+        } finally {
+            r.releaseLock();
+            w.releaseLock();
+        }
+    }
+
+    await Promise.allSettled([
+        pipe(cr, tw),
+        pipe(tr, cw),
+    ]);
+
+    target.close();
+    conn.close();
+}
+
+// Accept connections in a loop.
+try {
+    while (true) {
+        const { value: conn, done } = await acceptReader.read();
+
+        if (done) {
+            break;
+        }
+
+        handleClient(conn);
+    }
+} catch {
+    // Server closed.
+}

--- a/tests/test-fetch-proxy-auth.js
+++ b/tests/test-fetch-proxy-auth.js
@@ -1,0 +1,119 @@
+import assert from 'tjs:assert';
+import path from 'tjs:path';
+
+
+const decoder = new TextDecoder();
+const helperPath = path.join(import.meta.dirname, 'helpers', 'fetch-proxy-client.js');
+const proxyPath = path.join(import.meta.dirname, 'helpers', 'connect-proxy-auth.js');
+
+// The request target is a dead port: the request can only succeed by being
+// tunnelled through the auth proxy (which ignores this target and connects to
+// the real backend). If the authenticated proxy were silently dropped, the
+// client would hit this dead port directly and fail.
+const DEAD_TARGET = 'http://127.0.0.1:1/hello';
+
+
+async function runHelper(env) {
+    const proc = tjs.spawn([ tjs.exePath, 'run', helperPath ], {
+        stdout: 'pipe',
+        stderr: 'pipe',
+        env,
+    });
+    const [ status, stdout, stderr ] = (
+        await Promise.allSettled([ proc.wait(), proc.stdout.text(), proc.stderr.text() ])
+    ).map(r => r.value);
+
+    return { status, stdout, stderr };
+}
+
+
+async function startAuthProxy(backendPort, auth) {
+    const proc = tjs.spawn([ tjs.exePath, 'run', proxyPath ], {
+        stdout: 'pipe',
+        stderr: 'pipe',
+        env: { ...tjs.env, PROXY_AUTH: auth, BACKEND_PORT: String(backendPort) },
+    });
+
+    // Read the port from the proxy's first line of stdout.
+    const reader = proc.stdout.getReader();
+    let buf = '';
+
+    while (true) {
+        const { value, done } = await reader.read();
+
+        if (done) {
+            break;
+        }
+
+        buf += decoder.decode(value);
+
+        if (buf.includes('\n')) {
+            break;
+        }
+    }
+
+    reader.releaseLock();
+
+    return { proc, port: parseInt(buf.trim()) };
+}
+
+
+// An authenticated proxy URL (user:pass@host) routes through the proxy and
+// sends the Proxy-Authorization header. Regression test: lws_parse_uri_create
+// can't parse userinfo, so we must split it off ourselves — otherwise the
+// proxy is silently dropped.
+async function testAuthProxy() {
+    const backend = tjs.serve({
+        port: 0,
+        fetch: () => new Response('hello via auth proxy'),
+    });
+
+    const proxy = await startAuthProxy(backend.port, 'user:pass');
+
+    const env = { ...tjs.env };
+    env.http_proxy = `http://user:pass@127.0.0.1:${proxy.port}`;
+    env.TARGET_URL = DEAD_TARGET;
+
+    const { status, stdout, stderr } = await runHelper(env);
+
+    assert.eq(status.exit_status, 0, `child failed: ${stderr}`);
+
+    const result = JSON.parse(stdout.trim());
+
+    assert.eq(result.status, 200, 'status is 200');
+    assert.eq(result.body, 'hello via auth proxy', 'response came through the authenticated proxy');
+
+    proxy.proc.kill();
+    backend.close();
+}
+
+
+// Wrong proxy credentials are rejected (407): the proxy is genuinely
+// authenticating, and the request does not tunnel through.
+async function testAuthProxyWrongCreds() {
+    const backend = tjs.serve({
+        port: 0,
+        fetch: () => new Response('should not arrive'),
+    });
+
+    const proxy = await startAuthProxy(backend.port, 'user:pass');
+
+    const env = { ...tjs.env };
+    env.http_proxy = `http://user:wrong@127.0.0.1:${proxy.port}`;
+    env.TARGET_URL = DEAD_TARGET;
+
+    const { status, stdout } = await runHelper(env);
+
+    // The proxy answers 407 to the CONNECT, so the fetch must not succeed with
+    // the backend's body.
+    const succeeded = status.exit_status === 0 && stdout.includes('should not arrive');
+
+    assert.ok(!succeeded, 'request must not tunnel with wrong credentials');
+
+    proxy.proc.kill();
+    backend.close();
+}
+
+
+await testAuthProxy();
+await testAuthProxyWrongCreds();


### PR DESCRIPTION
Authenticated proxy URLs (http_proxy=http://user:pass@host:port) were
silently dropped. lws_parse_uri_create() does not parse userinfo (its
host scan stops at the first ':'), so "user:pass@host" parsed as
host="user", port=0, and tjs__parse_proxy_url() rejected it.

Split any "userinfo@" prefix off ourselves before handing the URL to
lws_parse_uri_create(), and pass it back to lws_set_proxy() (which
base64-encodes it for the Proxy-Authorization header) as part of
http_proxy_address, keeping the port separate.
