### PR TITLE
httpserver: restore query string in WS upgrade URI

### DIFF
--- a/src/httpserver.c
+++ b/src/httpserver.c
@@ -740,11 +740,29 @@ static int tjs_http_callback(struct lws *wsi, enum lws_callback_reasons reason, 
 
             uint64_t upgrade_id = uctx->id;
 
+            /* Reconstruct full URL including query string (lws strips it from uri_ptr). */
+            int query_len = lws_hdr_total_length(wsi, WSI_TOKEN_HTTP_URI_ARGS);
+            int needs_sep = query_len > 0 ? 1 : 0;
+            char *full_url = tjs__malloc((size_t) uri_len + needs_sep + query_len + 1);
+            if (!full_url) {
+                return -1;
+            }
+            memcpy(full_url, uri_ptr, (size_t) uri_len);
+
+            if (query_len > 0 &&
+                lws_hdr_copy(wsi, full_url + uri_len + 1, query_len + 1, WSI_TOKEN_HTTP_URI_ARGS) > 0) {
+                full_url[uri_len] = '?';
+            } else {
+                full_url[uri_len] = '\0';
+            }
+
             /* Call JS onRequest synchronously with upgrade ID and WS marker. */
             JSValue args[7];
             args[0] = JS_NewInt64(ctx, (int64_t) upgrade_id);
             args[1] = JS_NewString(ctx, method);
-            args[2] = JS_NewStringLen(ctx, uri_ptr, uri_len);
+            args[2] = JS_NewStringLen(ctx, full_url, strlen(full_url));
+            tjs__free(full_url);
+
             args[3] = headers_arr;
             args[4] = JS_NULL;
             args[5] = JS_NewString(ctx, uctx->remote_addr);

--- a/tests/helpers/serve-ws-url.js
+++ b/tests/helpers/serve-ws-url.js
@@ -1,0 +1,17 @@
+// WS server that echoes back the request URL seen at upgrade time.
+export default {
+    fetch(request, { server }) {
+        if (request.headers.get('upgrade') === 'websocket') {
+            server.upgrade(request, { data: request.url });
+
+            return;
+        }
+
+        return new Response('not a websocket request');
+    },
+    websocket: {
+        message(ws) {
+            ws.sendText(ws.data);
+        },
+    },
+};

--- a/tests/test-serve-websocket-query.js
+++ b/tests/test-serve-websocket-query.js
@@ -1,0 +1,30 @@
+import assert from 'tjs:assert';
+
+import { spawnServe } from './helpers/serve-spawn.js';
+
+
+// The upgrade Request must carry the full URL including the query string
+// (lws strips it from the URI header, so the server reconstructs it).
+async function testUpgradeUrlKeepsQueryString() {
+    const { proc, port } = await spawnServe('serve-ws-url.js');
+
+    try {
+        const ws = new WebSocket(`ws://127.0.0.1:${port}/ws?token=s3cr3t&x=1`);
+
+        const url = await new Promise((resolve, reject) => {
+            ws.onopen = () => ws.send('url?');
+            ws.onmessage = e => {
+                resolve(e.data);
+                ws.close();
+            };
+            ws.onerror = () => reject(new Error('WebSocket error'));
+        });
+
+        assert.ok(url.endsWith('/ws?token=s3cr3t&x=1'), `query string preserved (got: ${url})`);
+    } finally {
+        proc.kill('SIGTERM');
+        await proc.wait();
+    }
+}
+
+await testUpgradeUrlKeepsQueryString();


### PR DESCRIPTION
# Summary

`lws_http_get_uri_and_method()` returns only the URI path (e.g. `/ws`) and strips the query string (`?token=...`). The normal HTTP handler (`LWS_CALLBACK_HTTP`) already reconstructs the full URI via `WSI_TOKEN_HTTP_URI_ARGS`, but the WebSocket upgrade path (`LWS_CALLBACK_HTTP_CONFIRM_UPGRADE`) was passing only the bare path to the JavaScript `onRequest` handler.

This caused any JS code relying on `req.url` containing query parameters (e.g. `searchParams.get("token")`) to fail silently — `upgrade()` was never called and libwebsockets closed the connection with no response ("Empty reply from server").

## Root Cause

In `LWS_CALLBACK_HTTP_CONFIRM_UPGRADE` (~line 745), `args[2]` was set directly from `uri_ptr`:

```c
args[2] = JS_NewStringLen(ctx, uri_ptr, uri_len);
```

The same pattern in `LWS_CALLBACK_HTTP` (~line 798) correctly appends the query string:

```c
memcpy(req->url, uri_ptr, copy_len);
if (lws_hdr_copy(wsi, req->url + copy_len + 1, copy_query_len, WSI_TOKEN_HTTP_URI_ARGS) > 0) {
    req->url[copy_len] = '?';
}
```

The WS upgrade handler was simply missing this step.

## Fix

Applied the same URL reconstruction logic to the upgrade handler: copy `uri_ptr` into a local `full_url[2048]` buffer, then append `?` + the query string from `WSI_TOKEN_HTTP_URI_ARGS` when present. The constructed URL is passed to `args[2]` instead of the bare path.

## Testing

Verified on Android (arm64, Android 28) with a real WebSocket upgrade request:

```
> GET /ws?token=<uuid> HTTP/1.1
> Connection: Upgrade
> Upgrade: websocket
< HTTP/1.1 101 Switching Protocols
< Upgrade: WebSocket
< Connection: Upgrade
< Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=
```

Before the fix: `req.url` = `http://127.0.0.1:43125/ws` → token extraction returned `undefined` → upgrade rejected.

After the fix: `req.url` = `http://127.0.0.1:43125/ws?token=<uuid>` → token matches → HTTP 101, WebSocket data flows.