### PR TITLE
ws: handle lws_client_connect_via_info failure per WebSocket spec

### DIFF
--- a/src/ws.c
+++ b/src/ws.c
@@ -327,6 +327,25 @@ const struct lws_protocols tjs_ws_protocol = {
 };
 
 
+static JSValue emit_abnormal_close(JSContext *ctx, int argc, JSValue *argv) {
+    CHECK_EQ(argc, 1);
+
+    TJSWs *w = JS_GetOpaque(argv[0], tjs_ws_class_id);
+    if (w) {
+        JSContext *ctx = w->ctx;
+
+        JSValue err_reason = JS_NewString(ctx, "");
+        maybe_call_callback(w, WS_CALLBACK_ERROR, 1, &err_reason);
+
+        JSValue args[2] = {
+            JS_NewInt32(ctx, 1006),
+            JS_NewString(ctx, ""),
+        };
+        maybe_call_callback(w, WS_CALLBACK_CLOSE, 2, args);
+    }
+    return JS_UNDEFINED;
+}
+
 static JSValue tjs_ws_constructor(JSContext *ctx, JSValue new_target, int argc, JSValue *argv) {
     JSValue obj = JS_NewObjectClass(ctx, tjs_ws_class_id);
     if (JS_IsException(obj)) {
@@ -424,14 +443,19 @@ static JSValue tjs_ws_constructor(JSContext *ctx, JSValue new_target, int argc, 
     lws_parse_uri_destroy(&uri);
     js_free(ctx, full_path);
 
-    if (!wsi) {
-        /* Connection failed immediately. */
-        js_free(ctx, w);
-        JS_FreeValue(ctx, obj);
-        return JS_ThrowInternalError(ctx, "WebSocket connection failed");
-    }
-
     JS_SetOpaque(obj, w);
+
+    /* lws_client_connect_via_info can return NULL if no route to IP address is found,
+     * or even assert if no DNS server is found.
+     * In the future lws should be patched, but for now we work around the bug */
+    if (!wsi) {
+        /* Connection failed immediately — fire error and close events asynchronously. */
+        JSValue argv[1];
+        argv[0] = JS_DupValue(ctx, obj);
+        CHECK_EQ(JS_EnqueueJob(ctx, emit_abnormal_close, 1, argv), 0);
+        JS_FreeValue(ctx, argv[0]);
+        return obj;
+    }
 
     /* Prevent GC while connected. */
     w->this_val = JS_DupValue(ctx, obj);


### PR DESCRIPTION
When `lws_client_connect_via_info` returns `NULL` (e.g., no route to host, DNS resolution failure, connection refused), the old code freed the `TJSWs` struct, freed the JS object, and threw an `InternalError` exception. This contradicts the [WebSockets Standard](https://websockets.spec.whatwg.org/), which requires that such failures be reported via the `error` and `close` events, not via an exception.

Specifically, §4 "Feedback from the protocol" states:

> \- If the user agent was required to [fail the WebSocket connection](https://datatracker.ietf.org/doc/html/rfc6455#section-7.1.7), or if [the WebSocket connection was closed](https://datatracker.ietf.org/doc/html/rfc6455#section-7.1.4) after being flagged as full, [fire an event](https://dom.spec.whatwg.org/#concept-event-fire) named error at the [WebSocket](https://websockets.spec.whatwg.org/#websocket) object. [[WSP]](https://websockets.spec.whatwg.org/#biblio-wsp)
\- [Fire an event](https://dom.spec.whatwg.org/#concept-event-fire) named close at the [WebSocket](https://websockets.spec.whatwg.org/#websocket) object, using [CloseEvent](https://websockets.spec.whatwg.org/#closeevent), with the [wasClean](https://websockets.spec.whatwg.org/#dom-closeevent-wasclean) attribute initialized to true if the connection closed [cleanly](https://datatracker.ietf.org/doc/html/rfc6455#page-41:~:text=closed-,_cleanly_.) and false otherwise, the [code](https://websockets.spec.whatwg.org/#dom-closeevent-code) attribute initialized to [the WebSocket connection close code](https://datatracker.ietf.org/doc/html/rfc6455#section-7.1.5), and the [reason](https://websockets.spec.whatwg.org/#dom-closeevent-reason) attribute initialized to the result of applying [UTF-8 decode without BOM](https://encoding.spec.whatwg.org/#utf-8-decode-without-bom) to [the WebSocket connection close reason](https://datatracker.ietf.org/doc/html/rfc6455#section-7.1.6). [[WSP]](https://websockets.spec.whatwg.org/#biblio-wsp)


The spec further mandates that the user agent must not allow scripts to distinguish between different kinds of network failure (unreachable host, DNS failure, connection refused, TLS handshake failure, etc.) — all must result in close code 1006 (Abnormal Closure). An exception breaks this contract and prevents the user from handling the error asynchronously.

This fix:
1. Moves `JS_SetOpaque(obj, w)` before the `!wsi` check so the JS object always has its native data attached.
2. Replaces the exception with an enqueued job that emits the `error` callback (with an empty reason string, as no detailed error info is available from lws at this point) followed by the `close` callback with code **1006** and an empty reason.
3. Adds an early `return obj` after the enqueued job to skip unnecessary GC-rooting (`this_val`), lws connection refcounting, and `lws_cancel_service()` — none of which apply when no `wsi` was created.