### PR TITLE
ffi: fix size_t formatting

### DIFF
--- a/src/mod_ffi.c
+++ b/src/mod_ffi.c
@@ -507,7 +507,7 @@ static JSValue js_ffi_type_from_buffer(JSContext *ctx, JSValue this_val, int arg
     }
     size_t typesz = ffi_type_get_sz(type->ffi_type);
     if (bufsz != typesz) {
-        JS_ThrowRangeError(ctx, "expected buffer to be of size %lu", typesz);
+        JS_ThrowRangeError(ctx, "expected buffer to be of size %zu", typesz);
         return JS_EXCEPTION;
     }
     JSValue val = JS_UNDEFINED;


### PR DESCRIPTION
Fix the format specifier in `src/mod_ffi.c:510`. The value of type `size_t` was formatted with `%lu`, which is incorrect on platforms where `size_t` have different underlying type . On 32-bit architectures (e.g., i686, armv7, etc.), `size_t` is `unsigned int`, while `%lu` excepts `long unsigned int`. Even if they same byte size, they are distinct types in C, so `%lu` triggers a compiler error. Replaced with the correct `%zu` specifier, as per C99 standard for `size_t`.