### PR TITLE
fs: fix 64-bit stat/statFs field truncation

### DIFF
--- a/src/mod_fs.c
+++ b/src/mod_fs.c
@@ -224,7 +224,7 @@ static JSValue tjs_new_stat(JSContext *ctx, uv_stat_t *st) {
     sr->st_mode = st->st_mode;
 
 #define SET_UINT64_FIELD(x)                                                                                            \
-    JS_DefinePropertyValueStr(ctx, obj, STRINGIFY(x), JS_NewUint32(ctx, st->st_##x), JS_PROP_C_W_E);
+    JS_DefinePropertyValueStr(ctx, obj, STRINGIFY(x), JS_NewInt64(ctx, st->st_##x), JS_PROP_C_W_E);
 
     SET_UINT64_FIELD(dev);
     SET_UINT64_FIELD(mode);
@@ -265,7 +265,7 @@ static JSValue tjs_new_statfs(JSContext *ctx, uv_statfs_t *st) {
         return obj;
     }
 
-#define DEF_FIELD(x) JS_DefinePropertyValueStr(ctx, obj, STRINGIFY(x), JS_NewUint32(ctx, st->f_##x), JS_PROP_C_W_E);
+#define DEF_FIELD(x) JS_DefinePropertyValueStr(ctx, obj, STRINGIFY(x), JS_NewInt64(ctx, st->f_##x), JS_PROP_C_W_E);
     DEF_FIELD(type);
     DEF_FIELD(bsize);
     DEF_FIELD(blocks);

--- a/tests/test-fs-stat-large.js
+++ b/tests/test-fs-stat-large.js
@@ -1,0 +1,20 @@
+// Regression test: stat fields must not be truncated to 32 bits.
+// A sparse file larger than 4 GiB must report its true size, not size mod 2**32.
+import assert from 'tjs:assert';
+
+const big = 5 * 1024 * 1024 * 1024; // 5 GiB, well above the 2**32 wrap point
+
+const f = await tjs.makeTempFile('test_stat_largeXXXXXX');
+const path = f.path;
+try {
+    await f.truncate(big);
+
+    const st1 = await f.stat();
+    assert.eq(st1.size, big, 'FileHandle.stat().size must preserve values above 4 GiB');
+
+    const st2 = await tjs.stat(path);
+    assert.eq(st2.size, big, 'tjs.stat().size must preserve values above 4 GiB');
+} finally {
+    await f.close();
+    await tjs.remove(path);
+}


### PR DESCRIPTION
Accurate to 2**53, matching Node's non-bigint stat semantics.
