### PR TITLE
httpclient: send non-default port in the Host header

### DIFF
--- a/src/httpclient.c
+++ b/src/httpclient.c
@@ -766,6 +766,11 @@ static int tjs_httpclient_connect(TJSHttpClient *h) {
     char full_path[TJS_PATH_MAX];
     snprintf(full_path, sizeof(full_path), "/%s", uri->path);
 
+    /* lws emits cci.host verbatim as the Host header; include a non-default
+     * port so the server sees the correct authority (RFC 7230 §5.4). */
+    char host_hdr[512];
+    tjs__lws_format_host(host_hdr, sizeof(host_hdr), uri->scheme, uri->host, uri->port);
+
     struct lws_context *lws_ctx = tjs__lws_get_context(ctx);
     if (!lws_ctx) {
         lws_parse_uri_destroy(&uri);
@@ -779,7 +784,7 @@ static int tjs_httpclient_connect(TJSHttpClient *h) {
     cci.address = uri->host;
     cci.port = uri->port;
     cci.path = full_path;
-    cci.host = uri->host;
+    cci.host = host_hdr;
     cci.origin = uri->host;
     cci.ssl_connection = (use_ssl ? LCCSCF_USE_SSL : 0) | h->ssl_flags | LCCSCF_HTTP_NO_FOLLOW_REDIRECT |
                          LCCSCF_H2_QUIRK_OVERFLOWS_TXCR | LCCSCF_H2_QUIRK_NGHTTP2_END_STREAM;

--- a/src/lws-utils.c
+++ b/src/lws-utils.c
@@ -40,6 +40,24 @@
 extern const struct lws_protocols tjs_ws_protocol;
 extern const struct lws_protocols tjs_http_protocol;
 
+/* Format the value of the HTTP "Host" header for a client connection into buf.
+ * lws emits lws_client_connect_info.host verbatim, so a non-default port must
+ * be appended and IPv6 literals bracketed (RFC 7230 §5.4 / RFC 3986 §3.2.2).
+ * lws_parse_uri_create() stores IPv6 hosts without their brackets and defaults
+ * the port to 80 (http/ws) or 443 (https/wss). */
+void tjs__lws_format_host(char *buf, size_t buflen, const char *scheme, const char *host, int port) {
+    int default_port = (!strcmp(scheme, "https") || !strcmp(scheme, "wss")) ? 443 : 80;
+    bool is_ipv6 = strchr(host, ':') != NULL;
+    const char *lb = is_ipv6 ? "[" : "";
+    const char *rb = is_ipv6 ? "]" : "";
+
+    if (port == default_port) {
+        lws_snprintf(buf, buflen, "%s%s%s", lb, host, rb);
+    } else {
+        lws_snprintf(buf, buflen, "%s%s%s:%d", lb, host, rb, port);
+    }
+}
+
 #define TJS_LWS_HTTP_LOAD_PROTOCOL_NAME "tjs-http-load"
 
 typedef struct {
@@ -728,11 +746,16 @@ static int tjs__lws_load_http_once(TJSRuntime *qrt, TJSHttpLoadCtx *load_ctx, co
     struct lws_client_connect_info cci;
     memset(&cci, 0, sizeof(cci));
 
+    /* lws emits cci.host verbatim as the Host header; include a non-default
+     * port so the server sees the correct authority (RFC 7230 §5.4). */
+    char host_hdr[512];
+    tjs__lws_format_host(host_hdr, sizeof(host_hdr), uri->scheme, uri->host, uri->port);
+
     cci.context = lws_ctx;
     cci.address = ip_str;
     cci.port = uri->port;
     cci.path = full_path;
-    cci.host = uri->host;
+    cci.host = host_hdr;
     cci.origin = uri->host;
     cci.ssl_connection =
         (use_ssl ? LCCSCF_USE_SSL : 0) | LCCSCF_H2_QUIRK_OVERFLOWS_TXCR | LCCSCF_H2_QUIRK_NGHTTP2_END_STREAM;

--- a/src/private.h
+++ b/src/private.h
@@ -192,6 +192,7 @@ void tjs__lws_conn_ref(JSContext *ctx);
 void tjs__lws_conn_unref(JSContext *ctx);
 struct lws_vhost *tjs__lws_select_vhost(JSContext *ctx, const char *scheme, const char *hostname, int port);
 int tjs__lws_load_http(TJSRuntime *qrt, TBuf *dbuf, const char *url);
+void tjs__lws_format_host(char *buf, size_t buflen, const char *scheme, const char *host, int port);
 
 uv_loop_t *TJS_GetLoop(TJSRuntime *qrt);
 TJSRuntime *TJS_NewRuntimeWorker(void);

--- a/tests/test-fetch-host-port.js
+++ b/tests/test-fetch-host-port.js
@@ -1,0 +1,23 @@
+// tests/test-fetch-host-port.js
+// The client must include a non-default port in the Host header (RFC 7230
+// §5.4), so the server reconstructs the correct request URL.
+import assert from 'tjs:assert';
+
+const server = tjs.serve({
+    port: 0,
+    fetch: req => Response.json({
+        host: req.headers.get('host'),
+        url: req.url,
+    }),
+});
+
+const expectedHost = `127.0.0.1:${server.port}`;
+const url = `http://${expectedHost}/path`;
+
+const res = await fetch(url);
+const body = await res.json();
+
+assert.eq(body.host, expectedHost, 'Host header includes the non-default port');
+assert.eq(body.url, url, 'reconstructed request URL includes the port');
+
+await server.close();


### PR DESCRIPTION
## Problem

The lws-based HTTP client set `lws_client_connect_info.host` to the bare hostname (`uri->host`), and lws emits that value verbatim as the HTTP `Host` header. For a connection to a non-default port this sent e.g. `Host: 127.0.0.1` instead of `Host: 127.0.0.1:8080`, which violates [RFC 7230 §5.4](https://www.rfc-editor.org/rfc/rfc7230#section-5.4).

The most visible symptom: a `tjs.serve` handler reconstructs `req.url` from the `Host` header, so the request URL came back **without the port** (`http://127.0.0.1/path`). It affects `fetch`, `XMLHttpRequest`, and HTTP module imports — everything that goes through the client.

## Fix

Add `tjs__lws_format_host()`, which formats the `Host` value with a non-default port appended and IPv6 literals bracketed (RFC 7230 §5.4 / RFC 3986 §3.2.2), and use it on both client connect paths:
- `src/httpclient.c` — `fetch` / `XMLHttpRequest`
- `src/lws-utils.c` — synchronous HTTP module imports

## Verification

```
HOST HEADER: "127.0.0.1:55304"
req.url: http://127.0.0.1:55304/via-fetch   (and /via-xhr)
```

New regression test `tests/test-fetch-host-port.js` asserts both the `Host` header and the reconstructed `req.url` include the non-default port. Full suite passes (275/275).