### PR TITLE
httpserver: send END_STREAM for empty HTTP/2 responses

### DIFF
--- a/src/httpserver.c
+++ b/src/httpserver.c
@@ -1756,12 +1756,21 @@ static JSValue tjs_httpserver_send_response(JSContext *ctx, JSValue this_val, in
     if (body_len > 0) {
         lws_callback_on_writable(req->wsi);
     } else {
-        /* No body, complete the transaction now and release the request so
-         * a subsequent keep-alive transaction on this wsi doesn't accumulate
-         * the previous request's state.  The return value indicates whether
-         * lws will close the connection; we can't propagate that from here (we
-         * are not in the protocol callback), so we drop our state either way
-         * and let lws handle the wsi lifecycle. */
+        /* No body. Over HTTP/2 a response is not complete until its stream is
+         * closed with END_STREAM; the HEADERS frame alone leaves the peer
+         * waiting for a DATA frame (the transfer fails). Emit a zero-length
+         * LWS_WRITE_HTTP_FINAL to carry END_STREAM and end the stream. Over
+         * HTTP/1 the content-length: 0 header fully frames the response, so no
+         * terminator is needed. */
+        if (req->is_h2) {
+            lws_write(req->wsi, req->response_data + LWS_PRE + hdr_len, 0, LWS_WRITE_HTTP_FINAL);
+        }
+        /* Complete the transaction now and release the request so a subsequent
+         * keep-alive transaction on this wsi doesn't accumulate the previous
+         * request's state.  The return value indicates whether lws will close
+         * the connection; we can't propagate that from here (we are not in the
+         * protocol callback), so we drop our state either way and let lws handle
+         * the wsi lifecycle. */
         int must_close = lws_http_transaction_completed(req->wsi);
         (void) must_close;
         tjs_http_req_complete(s, req);

--- a/tests/test-serve-empty-request-body.js
+++ b/tests/test-serve-empty-request-body.js
@@ -1,0 +1,61 @@
+import assert from 'tjs:assert';
+import cert from './fixtures/server-cert.pem' with { type: 'text' };
+import key from './fixtures/server-key.pem' with { type: 'text' };
+
+// Reading the body of a bodyless request (e.g. a GET) must resolve to '' and the
+// handler must respond normally. Echoing that empty string back exercises an
+// empty response body, which over HTTP/2 must still close the stream with
+// END_STREAM — otherwise the client hangs and the request fails.
+//
+// The server advertises only "h2", so the connection is guaranteed to be
+// HTTP/2 (a client that can't negotiate h2 fails ALPN rather than downgrading),
+// which is the path that regressed. allowInsecure accepts the fixture cert.
+
+async function withServer(handler, fn) {
+    const server = tjs.serve({
+        port: 0,
+        listenIp: '127.0.0.1',
+        tls: { cert, key, alpn: [ 'h2' ] },
+        fetch: handler,
+    });
+
+    try {
+        return await fn(server.port);
+    } finally {
+        await server.close();
+    }
+}
+
+// Handler reads the request body and echoes it back verbatim.
+const echoBody = async req => new Response(await req.text());
+
+async function testBodylessGet() {
+    await withServer(echoBody, async port => {
+        const r = await fetch(`https://127.0.0.1:${port}/`, { allowInsecure: true });
+
+        assert.eq(r.status, 200, 'bodyless GET handler responds normally');
+        assert.eq(await r.text(), '', 'reading a bodyless request body resolves to empty string');
+    });
+}
+
+async function testEmptyPostBody() {
+    await withServer(echoBody, async port => {
+        const r = await fetch(`https://127.0.0.1:${port}/`, { allowInsecure: true, method: 'POST', body: '' });
+
+        assert.eq(r.status, 200, 'empty-body POST handler responds normally');
+        assert.eq(await r.text(), '', 'reading an empty POST body resolves to empty string');
+    });
+}
+
+async function testPostBodyRoundTrips() {
+    await withServer(echoBody, async port => {
+        const r = await fetch(`https://127.0.0.1:${port}/`, { allowInsecure: true, method: 'POST', body: 'hello body' });
+
+        assert.eq(r.status, 200, 'POST handler responds normally');
+        assert.eq(await r.text(), 'hello body', 'a POST body still round-trips');
+    });
+}
+
+await testBodylessGet();
+await testEmptyPostBody();
+await testPostBodyRoundTrips();


### PR DESCRIPTION
An empty response body over HTTP/2 (e.g. echoing back the empty body of a
bodyless request with new Response(await req.text())) failed the request with
"Network request failed". The buffered response path wrote the HEADERS frame
and then called lws_http_transaction_completed() without ever closing the h2
stream, so the peer kept waiting for a DATA frame and the transfer never
completed. (Over HTTP/1 the content-length: 0 header fully frames the response,
so h1 was unaffected.)

Emit a zero-length LWS_WRITE_HTTP_FINAL for the no-body case over h2 to carry
END_STREAM and close the stream before completing the transaction, matching the
END_STREAM the non-empty and streaming paths already set on their final write.

Add tests/test-serve-empty-request-body.js covering: reading a bodyless GET
body resolves to '' and the handler responds normally over h2, an empty POST
body reads as '', and a POST body still round-trips.
