### PR TITLE
test: cover Set-Cookie Secure/HttpOnly cookie-jar persistence

### DIFF
--- a/tests/helpers/set-cookie-secure-httponly.js
+++ b/tests/helpers/set-cookie-secure-httponly.js
@@ -1,0 +1,25 @@
+// Fixture for test-fetch-cookie-secure-httponly.js (issue #1064).
+//
+// Runs in a child process with an isolated TJS_HOME so the cookie jar it
+// writes can be inspected without touching the user's real ~/.tjs. Replays
+// the exact repro from the issue: a credentialed request against a server
+// whose Set-Cookie carries the Secure and HttpOnly flags.
+const server = tjs.serve({
+    port: 0,
+    listenIp: '127.0.0.1',
+    fetch: () => new Response(null, {
+        status: 302,
+        headers: {
+            'Location': '/',
+            'Set-Cookie': 'session=abc123def456; Path=/; Secure; HttpOnly',
+        },
+    }),
+});
+
+await fetch(`http://127.0.0.1:${server.port}/login`, {
+    method: 'POST',
+    redirect: 'manual',
+    credentials: 'include',
+});
+
+await server.close();

--- a/tests/test-fetch-cookie-secure-httponly.js
+++ b/tests/test-fetch-cookie-secure-httponly.js
@@ -31,7 +31,8 @@ try {
 
     // Netscape cookie jar, tab-separated:
     // domain  hostonly  path  secure  expires  name  value
-    const line = jar.split('\n').find(l => l && !l.startsWith('#'));
+    // Split on \r?\n: the jar is written with \r\n line endings on Windows.
+    const line = jar.split(/\r?\n/).find(l => l && !l.startsWith('#'));
     assert.ok(line, 'a cookie was persisted');
 
     const fields = line.split('\t');

--- a/tests/test-fetch-cookie-secure-httponly.js
+++ b/tests/test-fetch-cookie-secure-httponly.js
@@ -1,0 +1,44 @@
+import assert from 'tjs:assert';
+import path from 'tjs:path';
+
+// Regression test for issue #1064: a Set-Cookie whose attributes include
+// Secure and/or HttpOnly must be persisted to the cookie jar with its real
+// name and value. An upstream libwebsockets parser bug (warmcat #3652)
+// aliased the httponly/secure flags onto the cookie name/value slots and
+// clobbered both with the literal string "T", breaking session persistence
+// for `credentials: 'include'` fetches and XMLHttpRequest.withCredentials.
+//
+// The cookie jar path is a process-level singleton fixed at startup from
+// TJS_HOME, so we replay the request in a child process with an isolated
+// TJS_HOME and inspect the jar it writes.
+
+const tmpHome = await tjs.makeTempDir('tjs-cookie-jar-XXXXXX');
+try {
+    const args = [
+        tjs.exePath,
+        'run',
+        path.join(import.meta.dirname, 'helpers', 'set-cookie-secure-httponly.js'),
+    ];
+    const proc = tjs.spawn(args, {
+        stdout: 'ignore',
+        stderr: 'pipe',
+        env: { ...tjs.env, TJS_HOME: tmpHome },
+    });
+    const [ status, stderr ] = await Promise.all([ proc.wait(), proc.stderr.text() ]);
+    assert.eq(status.exit_status, 0, `child exited non-zero: ${stderr}`);
+
+    const jar = new TextDecoder().decode(await tjs.readFile(path.join(tmpHome, 'cookies.txt')));
+
+    // Netscape cookie jar, tab-separated:
+    // domain  hostonly  path  secure  expires  name  value
+    const line = jar.split('\n').find(l => l && !l.startsWith('#'));
+    assert.ok(line, 'a cookie was persisted');
+
+    const fields = line.split('\t');
+    assert.eq(fields.length, 7, 'cookie line has all Netscape fields');
+    assert.eq(fields[3], 'TRUE', 'Secure flag parsed onto its own column');
+    assert.eq(fields[5], 'session', 'cookie name is intact (not clobbered to "T")');
+    assert.eq(fields[6], 'abc123def456', 'cookie value is intact (not clobbered to "T")');
+} finally {
+    await tjs.remove(tmpHome);
+}


### PR DESCRIPTION
## Summary

Adds a regression test for the cookie-jar corruption reported in #1064: when a server's `Set-Cookie` carries the `Secure` and/or `HttpOnly` attributes, the persisted cookie had its **name and value clobbered to the literal string `"T"`**, breaking session persistence for `credentials: 'include'` fetches and `XMLHttpRequest.withCredentials`.

The root cause was an upstream libwebsockets parser bug ([warmcat/libwebsockets#3652](https://github.com/warmcat/libwebsockets/issues/3652)) — `lws_parse_set_cookie()` indexed two arrays with mismatched orderings, so the `httponly`/`secure` flags aliased the name/value slots. It is **already fixed** in the current lws pin (commit `2efe9b780`, *"http: cookies: normalize ordering"*, which cites #3652). This PR just adds a test so it stays fixed.

## Test design

The cookie-jar path is a process-level singleton fixed at startup from `TJS_HOME`, so the test replays the issue's exact repro in a child process with an isolated `TJS_HOME` and inspects the jar it writes:

- fixed runtime → `127.0.0.1	TRUE	/	TRUE	0	session	abc123def456`
- buggy runtime → `127.0.0.1	TRUE	/	FALSE	0	T	T`

The test asserts the persisted name/value are intact and the `Secure` flag landed in its own column.

## Verification

- Passes on the current (fixed) runtime.
- Confirmed it **fails** against the real pre-fix `cookie.c` (parent of `2efe9b780`), reproducing the exact `T`/`T` corruption — so it is a genuine regression test, then reverted.
- Full suite: 378 tests, all OK.

Closes #1064